### PR TITLE
Add warning when there isn't a url

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -147,12 +147,12 @@ class HomeAssistantSkill(FallbackSkill):
         except Timeout:
             self.speak_dialog('homeassistant.error.offline')
         except (InvalidURL, URLRequired, MaxRetryError) as e:
-            if e.request.url is True:
-                self.speak_dialog('homeassistant.error.invalidurl', data={
-                'url': e.request.url})
-            elif e.request.url is False:
+            if e.request is None or e.request.url is None:
                 # There is no url configured
                 self.speak_dialog('homeassistant.error.needurl')
+            else:
+                self.speak_dialog('homeassistant.error.invalidurl', data={
+                'url': e.request.url})
         except SSLError:
             self.speak_dialog('homeassistant.error.ssl')
         except HTTPError as e:

--- a/__init__.py
+++ b/__init__.py
@@ -147,8 +147,12 @@ class HomeAssistantSkill(FallbackSkill):
         except Timeout:
             self.speak_dialog('homeassistant.error.offline')
         except (InvalidURL, URLRequired, MaxRetryError) as e:
-            self.speak_dialog('homeassistant.error.invalidurl', data={
+            if e.request.url is True:
+                self.speak_dialog('homeassistant.error.invalidurl', data={
                 'url': e.request.url})
+            elif e.request.url is False:
+                # There is no url configured
+                self.speak_dialog('homeassistant.error.needurl')
         except SSLError:
             self.speak_dialog('homeassistant.error.ssl')
         except HTTPError as e:

--- a/dialog/en-us/homeassistant.error.needurl.dialog
+++ b/dialog/en-us/homeassistant.error.needurl.dialog
@@ -1,3 +1,3 @@
-You need to in put a url in Mycroft home.
-You need to setup the skill by putting a url in Mycroft home.
-To use this skill, put a url in Mycroft home.
+You need to in put a URL in Mycroft home.
+You need to setup the skill by putting a URL in Mycroft home.
+To use this skill, put a URL in Mycroft home.

--- a/dialog/en-us/homeassistant.error.needurl.dialog
+++ b/dialog/en-us/homeassistant.error.needurl.dialog
@@ -1,0 +1,3 @@
+You need to in put a url in Mycroft home.
+You need to setup the skill by putting a url in Mycroft home.
+To use this skill, put a url in Mycroft home.


### PR DESCRIPTION
## Description:

Fixes the issue where the skill fails to report back the error (ironically) because a url is not set.

## Checklist:
  - [x] Code is Python 3.x compatible
  - [x] Travis is passing tests **Your PR cannot be merged unless tests pass**
  - [x] No PEP Bot Errors or Issues