### PR TITLE
Remove old buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
-[![Stories in Ready](https://badge.waffle.io/btotharye/mycroft-homeassistant.svg?label=ready&title=Ready)](http://waffle.io/btotharye/mycroft-homeassistant) 
-[![Build Status](https://travis-ci.org/btotharye/mycroft-homeassistant.svg?branch=master)](https://travis-ci.org/btotharye/mycroft-homeassistant)
-[![Coverage Status](https://coveralls.io/repos/github/btotharye/mycroft-homeassistant/badge.svg?branch=master)](https://coveralls.io/github/btotharye/mycroft-homeassistant?branch=master)
-[![Discord](https://img.shields.io/discord/348442860510642176.svg)](https://discord.gg/Xnn89dB)
-
 # <img src='https://raw.githack.com/FortAwesome/Font-Awesome/master/svgs/solid/home.svg' card_color='#000000' width='50' height='50' style='vertical-align:bottom'/> Home Assistant
 Control Home Assistant devices
 


### PR DESCRIPTION
Just a quick clean up of the README buttons they seem to be pointing to old or soon to be deprecated systems.

