### PR TITLE
revert all values to match previous settingsmeta.json

### DIFF
--- a/settingsmeta.yaml
+++ b/settingsmeta.yaml
@@ -4,7 +4,7 @@ skillMetadata:
     fields:
     - name: host
       type: text
-      label: Host address or IP address
+      label: Host adress or ip number
       value: ''
     - name: token
       type: password
@@ -19,12 +19,12 @@ skillMetadata:
     - name: ssl
       type: checkbox
       label: Use SSL
-      value: "False"
+      value: "false"
     - name: verify
       type: checkbox
       label: Verify SSL Certificate
-      value: "True"
+      value: "true"
     - name: enable_fallback
       type: checkbox
       label: Enable conversation component as fallback
-      value: "True"
+      value: "true"


### PR DESCRIPTION
In the change to settingsmeta.yaml some labels were changed to remove typo's. This changes the hash, and therefore is treated as a new settings block. 

This commit restores the prior marketplace hash thereby retaining settings for all users using the marketplace version.
