### PR TITLE
Fix responses requirement to <=0.10.15

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 fuzzywuzzy==0.14.0
 python-Levenshtein==0.12.0
 requests
-responses
+responses<=0.10.15


### PR DESCRIPTION
## Description:

the dependency responses >0.10.15 needs a urllib3 version that is higher then the one needed by the fixed requests dependency of mycroft-core.
