### PR TITLE
Bugfix - Skill fails on first run when settings not yet defined

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -152,41 +152,18 @@ class HomeAssistantSkill(CommonIoTSkill, FallbackSkill):
 
     def initialize(self):
         self.settings_change_callback = self.on_websettings_changed
-        if not self._client:
-            self._create_client()
-        self._entities = self._build_entities_map(self._client.entities())
-        self._scenes = self._build_scenes_map(self._client.entities())
-        self._brightness_step = self.settings.get("brightness_step", 20)
-        self._temperature_step = self.settings.get("temperature_step", 20)
-        self.register_entities_and_scenes()
-
+        self.on_websettings_changed()
+        # TODO: If a user toggles this setting off, it will not de-register 
+        # the fallback. Should be moved to on_websettings_changed()
         # Needs higher priority than general fallback skills
         if self.settings.get('enable_fallback'):
             self.register_fallback(self.handle_fallback, 2)
 
-    def _build_entities_map(self, entities: dict):
-        results = defaultdict(list)
-        for id, name in entities.items():
-            if name:
-                name = name.lower()
-            domain = self._domain(id)
-            if domain in _DOMAINS and domain != _SCENE:
-                results[name].append(id)
-        return results
-
-    def _build_scenes_map(self, entities: dict):
-        results = dict()
-        for id, name in entities.items():
-            if not name:
-                continue
-            name = name.lower()
-            if self._domain(id) == _SCENE:
-                results[name] = id
-        return results
-
     def on_websettings_changed(self):
         # Force a setting refresh after the websettings changed
         # Otherwise new settings will not be regarded
+        self._brightness_step = self.settings.get("brightness_step")
+        self._temperature_step = self.settings.get("temperature_step")
         self._create_client()
 
     def _create_client(self):
@@ -222,6 +199,30 @@ class HomeAssistantSkill(CommonIoTSkill, FallbackSkill):
             )
         except ConnectionError:
             self.speak_dialog('error.connection')
+
+        self._entities = self._build_entities_map(self._client.entities())
+        self._scenes = self._build_scenes_map(self._client.entities())
+        self.register_entities_and_scenes()
+
+    def _build_entities_map(self, entities: dict):
+        results = defaultdict(list)
+        for id, name in entities.items():
+            if name:
+                name = name.lower()
+            domain = self._domain(id)
+            if domain in _DOMAINS and domain != _SCENE:
+                results[name].append(id)
+        return results
+
+    def _build_scenes_map(self, entities: dict):
+        results = dict()
+        for id, name in entities.items():
+            if not name:
+                continue
+            name = name.lower()
+            if self._domain(id) == _SCENE:
+                results[name] = id
+        return results
 
     def _domain(self, entity_id: str):
         if entity_id is None:

--- a/__init__.py
+++ b/__init__.py
@@ -152,7 +152,8 @@ class HomeAssistantSkill(CommonIoTSkill, FallbackSkill):
 
     def initialize(self):
         self.settings_change_callback = self.on_websettings_changed
-        self._setup()
+        if not self._client:
+            self._create_client()
         self._entities = self._build_entities_map(self._client.entities())
         self._scenes = self._build_scenes_map(self._client.entities())
         self._brightness_step = self.settings.get("brightness_step", 20)
@@ -186,21 +187,41 @@ class HomeAssistantSkill(CommonIoTSkill, FallbackSkill):
     def on_websettings_changed(self):
         # Force a setting refresh after the websettings changed
         # Otherwise new settings will not be regarded
-        self._force_setup()
+        self._create_client()
 
-    def _setup(self):
-        portnumber = int(self.settings.get('portnum', 8123))
-        self._client = HomeAssistantClient(
-            token=self.settings.get('token'),
-            hostname=self.settings.get('host', 'localhost'),
-            port=portnumber,
-            ssl=self.settings.get('ssl', False),
-            verify=self.settings.get('verify', True)
-        )
+    def _create_client(self):
+        """Create the Home Assistant Client from Skill settings.
+        
+        :param None
+        :return None
+        """
+        host = self.settings.get('host')
+        token = self.settings.get('token')
+        if not host: 
+            # Assume settings haven't been entered.
+            return
+        if not token:
+            # Ensure access token exists if other settings have been entered
+            self.speak_dialog('error.no.token')
+            return
+        try:
+            # Ensure port number is an integer. Default value assumed.
+            port_number = int(self.settings.get('portnum'))
+        except TypeError:
+            self.speak_dialog('error.parsing.number',
+                              {'port_number': port_number})
+            return
 
-    def _force_setup(self):
-        LOGGER.debug('Creating a new HomeAssistant-Client')
-        self._setup()
+        try:
+            self._client = HomeAssistantClient(
+                token=token,
+                hostname=host,
+                port=port_number,
+                ssl=self.settings.get('ssl'),
+                verify=self.settings.get('verify')
+            )
+        except ConnectionError:
+            self.speak_dialog('error.connection')
 
     def _domain(self, entity_id: str):
         if entity_id is None:

--- a/dialog/en-us/error.connection.dialog
+++ b/dialog/en-us/error.connection.dialog
@@ -1,0 +1,5 @@
+Failed to connect to the home assistant host. Please check your Skill settings.
+Failed to connect to the home assistant host. Please check your Skill settings.
+Failed to connect to the home assistant host. Please check your Skill settings.
+Failed to connect to the home assistant host. Please check your Skill settings.
+Failed to connect to the home assistant host. Have you tried turning it off and on again?

--- a/dialog/en-us/error.no.token.dialog
+++ b/dialog/en-us/error.no.token.dialog
@@ -1,0 +1,1 @@
+I did not receive a valid home assistant token. Please check your skill settings.

--- a/dialog/en-us/error.parsing.number.dialog
+++ b/dialog/en-us/error.parsing.number.dialog
@@ -1,0 +1,1 @@
+{port_number} does not seem to be a valid port number. Please check your home assistant skill settings.


### PR DESCRIPTION
Restructure Skill initialization to handle the first run of the Skill when settings haven't yet been entered by the user.

`on_websettings_changed()` now creates the HA client, and settings fetching got moved here to ensure settings get updated in Skill when changed remotely. 
Removed default settings values from the `settings.get()` methods to rely on the default values in settingsmeta. This means they will only need to be updated in one location. If the settings aren't available we do not know which host to connect to anyway.
Also added some settings validation and error messages for common failure scenarios.