### PR TITLE
Issue #63: STT engine return percentage as symbol

### DIFF
--- a/test/intent/006.SetLightBright.intent.json
+++ b/test/intent/006.SetLightBright.intent.json
@@ -1,4 +1,4 @@
 {
-  "utterance": "set brightness of kitchen light to 40 percent",
+  "utterance": "set brightness of kitchen light to 40%",
   "expected_dialog": "homeassistant.brightness.dimmed"
 }

--- a/test/intent/016.SetLightBrightUnknown.intent.json
+++ b/test/intent/016.SetLightBrightUnknown.intent.json
@@ -1,4 +1,4 @@
 {
-  "utterance": "set brightness of tank light to 40 percent",
+  "utterance": "set brightness of tank light to 40%",
   "expected_dialog": "homeassistant.device.unknown"
 }

--- a/vocab/ca-es/set.light.brightness.intent
+++ b/vocab/ca-es/set.light.brightness.intent
@@ -1,1 +1,1 @@
-estableix la {{entity}} al {{brightnessvalue}} per cent
+estableix la {{entity}} al {{brightnessvalue}}%

--- a/vocab/cs-cz/set.light.brightness.intent
+++ b/vocab/cs-cz/set.light.brightness.intent
@@ -1,1 +1,1 @@
-(nastav|změň|zvyš|sniž) intenzitu {{entity}} na {{brightnessvalue}} procent
+(nastav|změň|zvyš|sniž) intenzitu {{entity}} na {{brightnessvalue}}%

--- a/vocab/da-dk/set.light.brightness.intent
+++ b/vocab/da-dk/set.light.brightness.intent
@@ -1,1 +1,1 @@
-sæt lysstyrken på {{enhed}} til {{brightnessvalue}} procent
+sæt lysstyrken på {{enhed}} til {{brightnessvalue}}%

--- a/vocab/de-de/set.light.brightness.intent
+++ b/vocab/de-de/set.light.brightness.intent
@@ -1,1 +1,1 @@
-Setze die Helligkeit von {{entity}} auf {{brightnessvalue}} Prozent
+Setze die Helligkeit von {{entity}} auf {{brightnessvalue}}%

--- a/vocab/en-us/set.light.brightness.intent
+++ b/vocab/en-us/set.light.brightness.intent
@@ -1,1 +1,1 @@
-set brightness of {{entity}} to {{brightnessvalue}} percent
+set brightness of {{entity}} to {{brightnessvalue}}%

--- a/vocab/es-es/set.light.brightness.intent
+++ b/vocab/es-es/set.light.brightness.intent
@@ -1,1 +1,1 @@
-establece el brillo de {{entity}} a {{brightnessvalue}} por ciento
+establece el brillo de {{entity}} a {{brightnessvalue}}%

--- a/vocab/es-lm/set.light.brightness.intent
+++ b/vocab/es-lm/set.light.brightness.intent
@@ -1,1 +1,1 @@
-establece el brillo de {{entity}} a {{brightnessvalue}} por ciento
+establece el brillo de {{entity}} a {{brightnessvalue}}%

--- a/vocab/fr-fr/set.light.brightness.intent
+++ b/vocab/fr-fr/set.light.brightness.intent
@@ -1,1 +1,1 @@
-met la luminosité de {{entity}} à {{brightnessvalue}} pourcent
+met la luminosité de {{entity}} à {{brightnessvalue}}%

--- a/vocab/gl-es/set.light.brightness.intent
+++ b/vocab/gl-es/set.light.brightness.intent
@@ -1,1 +1,1 @@
-definir o brillo de {{entity}} ata o {{brightnessvalue}} por cento
+definir o brillo de {{entity}} ata o {{brightnessvalue}}%

--- a/vocab/it-it/set.light.brightness.intent
+++ b/vocab/it-it/set.light.brightness.intent
@@ -1,1 +1,1 @@
-imposta la luminosità di {{entity}} (al |all'){{brightnessvalue}} (|percento)
+imposta la luminosità di {{entity}} (al |all'){{brightnessvalue}}%

--- a/vocab/nl-nl/set.light.brightness.intent
+++ b/vocab/nl-nl/set.light.brightness.intent
@@ -1,1 +1,1 @@
-zet (de )?helderheid van {{entity}} op {{brightnessvalue}} procent
+zet (de )?helderheid van {{entity}} op {{brightnessvalue}}%

--- a/vocab/pl-pl/set.light.brightness.intent
+++ b/vocab/pl-pl/set.light.brightness.intent
@@ -1,1 +1,1 @@
-ustaw jasność {{entity}} na {{brightnessvalue}} procent
+ustaw jasność {{entity}} na {{brightnessvalue}}%

--- a/vocab/pt-br/set.light.brightness.intent
+++ b/vocab/pt-br/set.light.brightness.intent
@@ -1,1 +1,1 @@
-definir o brilho de {{entity}} para {{brightnessvalue}} por cento
+definir o brilho de {{entity}} para {{brightnessvalue}}%

--- a/vocab/sv-se/set.light.brightness.intent
+++ b/vocab/sv-se/set.light.brightness.intent
@@ -1,1 +1,1 @@
-ställ in ljusstyrka av {{entity}} till {{brightnessvalue}} procent
+ställ in ljusstyrka av {{entity}} till {{brightnessvalue}}%


### PR DESCRIPTION
#### Description
fix issue #63 - intent to set light brightness percentage, STT return percentage as symbol
Updated all languages

#### Type of PR
- [x] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements
