### PR TITLE
Fix #65: cannot obtain values from entity that exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,7 @@ def handle_lighting_intent(self, message):
  * Script intents processing
  * New intent for opening/closing cover entities
  * New intent for locking/unlocking lock entities (with added security?)
- * New intent for thermostat values, raising, etc.
  * New intent to handle multimedia/kodi
 
 ## In Development
-* Increasing and Decreasing Climate controls
+ * A lot of small stuffs

--- a/__init__.py
+++ b/__init__.py
@@ -499,10 +499,10 @@ class HomeAssistantSkill(FallbackSkill):
             current_temp = nice_number((float(attributes['current_temperature'])), lang=self.language)
             target_temp = nice_number((float(attributes['temperature'])), lang=self.language)
             self.speak_dialog('homeassistant.sensor.thermostat', data={
-            "dev_name": sensor_name,
-            "value": sensor_state,
-            "current_temp": current_temp,
-            "targeted_temp": target_temp})
+                "dev_name": sensor_name,
+                "value": sensor_state,
+                "current_temp": current_temp,
+                "targeted_temp": target_temp})
         else:
             self.speak_dialog('homeassistant.sensor', data={
                 "dev_name": sensor_name,

--- a/__init__.py
+++ b/__init__.py
@@ -484,7 +484,7 @@ class HomeAssistantSkill(FallbackSkill):
             if len(quantity) > 0:
                 quantity = quantity[0]
                 if (quantity.unit.name != "dimensionless" and
-                        quantity.uncertainty <= 0.5):
+                        (quantity.uncertainty != None and quantity.uncertainty <= 0.5)):
                     sensor_unit = quantity.unit.name
                     sensor_state = quantity.value
 

--- a/__init__.py
+++ b/__init__.py
@@ -377,7 +377,7 @@ class HomeAssistantSkill(FallbackSkill):
                                   data=ha_entity)
             else:
                 light_attrs = self.ha.find_entity_attr(ha_entity['id'])
-                if light_attrs['unit_measure'] is None:
+                if light_attrs['unit_measure'] is "":
                     self.speak_dialog(
                         'homeassistant.brightness.cantdim.dimmable',
                         data=ha_entity)
@@ -399,7 +399,7 @@ class HomeAssistantSkill(FallbackSkill):
                     data=ha_entity)
             else:
                 light_attrs = self.ha.find_entity_attr(ha_entity['id'])
-                if light_attrs['unit_measure'] is None:
+                if light_attrs['unit_measure'] is "":
                     self.speak_dialog(
                         'homeassistant.brightness.cantdim.dimmable',
                         data=ha_entity)

--- a/__init__.py
+++ b/__init__.py
@@ -461,6 +461,8 @@ class HomeAssistantSkill(FallbackSkill):
             return
 
         entity = ha_entity['id']
+        domain = entity.split(".")[0]
+        attributes = ha_entity['attributes']
 
         # IDEA: set context for 'read it out again' or similar
         # self.set_context('Entity', ha_entity['dev_name'])
@@ -493,10 +495,19 @@ class HomeAssistantSkill(FallbackSkill):
         except ValueError:
             pass
 
-        self.speak_dialog('homeassistant.sensor', data={
+        if domain == "climate" and not sensor_state == '':
+            current_temp = nice_number((float(attributes['current_temperature'])), lang=self.language)
+            target_temp = nice_number((float(attributes['temperature'])), lang=self.language)
+            self.speak_dialog('homeassistant.sensor.thermostat', data={
             "dev_name": sensor_name,
             "value": sensor_state,
-            "unit": sensor_unit})
+            "current_temp": current_temp,
+            "targeted_temp": target_temp})
+        else:
+            self.speak_dialog('homeassistant.sensor', data={
+                "dev_name": sensor_name,
+                "value": sensor_state,
+                "unit": sensor_unit})
         # IDEA: Add some context if the person wants to look the unit up
         # Maybe also change to name
         # if one wants to look up "outside temperature"

--- a/__init__.py
+++ b/__init__.py
@@ -495,7 +495,7 @@ class HomeAssistantSkill(FallbackSkill):
         except ValueError:
             pass
 
-        if domain == "climate" and not sensor_state == '':
+        if domain == "climate" and sensor_state != '':
             current_temp = nice_number((float(attributes['current_temperature'])), lang=self.language)
             target_temp = nice_number((float(attributes['temperature'])), lang=self.language)
             self.speak_dialog('homeassistant.sensor.thermostat', data={

--- a/__init__.py
+++ b/__init__.py
@@ -483,8 +483,7 @@ class HomeAssistantSkill(FallbackSkill):
                 sensor_name, sensor_state, sensor_unit)))
             if len(quantity) > 0:
                 quantity = quantity[0]
-                if (quantity.unit.name != "dimensionless" and
-                        (quantity.uncertainty != None and quantity.uncertainty <= 0.5)):
+                if (quantity.unit.name != "dimensionless"):
                     sensor_unit = quantity.unit.name
                     sensor_state = quantity.value
 

--- a/__init__.py
+++ b/__init__.py
@@ -377,7 +377,7 @@ class HomeAssistantSkill(FallbackSkill):
                                   data=ha_entity)
             else:
                 light_attrs = self.ha.find_entity_attr(ha_entity['id'])
-                if light_attrs['unit_measure'] is "":
+                if light_attrs['unit_measure'] == "":
                     self.speak_dialog(
                         'homeassistant.brightness.cantdim.dimmable',
                         data=ha_entity)
@@ -399,7 +399,7 @@ class HomeAssistantSkill(FallbackSkill):
                     data=ha_entity)
             else:
                 light_attrs = self.ha.find_entity_attr(ha_entity['id'])
-                if light_attrs['unit_measure'] is "":
+                if light_attrs['unit_measure'] == "":
                     self.speak_dialog(
                         'homeassistant.brightness.cantdim.dimmable',
                         data=ha_entity)
@@ -455,7 +455,7 @@ class HomeAssistantSkill(FallbackSkill):
         entity = message.data["Entity"]
         self.log.debug("Entity: %s" % entity)
 
-        ha_entity = self._find_entity(entity, ['sensor', 'switch'])
+        ha_entity = self._find_entity(entity, ['climate', 'sensor', 'switch'])
         # Exit if entiti not found or is unavailabe
         if not ha_entity or not self._check_availability(ha_entity):
             return

--- a/dialog/cs-cz/homeassistant.sensor.thermostat.dialog
+++ b/dialog/cs-cz/homeassistant.sensor.thermostat.dialog
@@ -1,0 +1,3 @@
+Momentálně je režim {dev_name} {value}, současná teplota je {current_temp} a nastavená {targeted_temp}.
+Režim {dev_name} je {value}, současná teplota je {current_temp} a nastavená {targeted_temp}.
+{dev_name} je {value}, aktuální teplota je {current_temp} a nastavená {targeted_temp}.

--- a/dialog/de-de/homeassistant.sensor.thermostat.dialog
+++ b/dialog/de-de/homeassistant.sensor.thermostat.dialog
@@ -1,0 +1,3 @@
+Der aktuelle Status von {dev_name} ist {value}, die aktuelle Temperatur ist {current_temp} und die Zieltemperatur {targeted_temp}.
+{dev_name} Status ist {value}, die aktuelle Temperatur ist {current_temp} und die Zieltemperatur {targeted_temp}.
+{dev_name} ist {value}, Temperatur ist {current_temp} und auf {targeted_temp} eingestellt.

--- a/dialog/en-us/homeassistant.sensor.thermostat.dialog
+++ b/dialog/en-us/homeassistant.sensor.thermostat.dialog
@@ -1,0 +1,3 @@
+Currently {dev_name} mode is {value}, current temperature is {current_temp} and targeted {targeted_temp}.
+{dev_name} mode is {value}, current temperature is {current_temp} and targeted {targeted_temp}.
+{dev_name} is {value}, temperature is {current_temp} and set to {targeted_temp}.

--- a/ha_client.py
+++ b/ha_client.py
@@ -113,7 +113,7 @@ class HomeAssistantClient(object):
                         else:
                             unit_measur = entity_attrs['unit_of_measurement']
                     except KeyError:
-                        unit_measur = None
+                        unit_measur = ""
                     # IDEA: return the color if available
                     # TODO: change to return the whole attr dictionary =>
                     # free use within handle methods

--- a/ha_client.py
+++ b/ha_client.py
@@ -77,7 +77,8 @@ class HomeAssistantClient(object):
                                 "dev_name": state['attributes']
                                 ['friendly_name'],
                                 "state": state['state'],
-                                "best_score": best_score}
+                                "best_score": best_score,
+                                "attributes":state['attributes']}
                         score = fuzz.token_sort_ratio(
                             entity,
                             state['entity_id'].lower())
@@ -88,7 +89,8 @@ class HomeAssistantClient(object):
                                 "dev_name": state['attributes']
                                 ['friendly_name'],
                                 "state": state['state'],
-                                "best_score": best_score}
+                                "best_score": best_score,
+                                "attributes":state['attributes']}
                 except KeyError:
                     pass
             return best_entity


### PR DESCRIPTION
#### Description
There seems to be an issue on the latest version of the skill that is descibed here: #65 

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
_Either delete those that do not apply, or add an x between the square brackets like so: `- [x]`_
- [X] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements