### PR TITLE
remove optional `thermostat` keyword

### DIFF
--- a/vocab/de-de/sensor.intent
+++ b/vocab/de-de/sensor.intent
@@ -1,1 +1,1 @@
-(was ist|wie ist|sag mir) (den|der|) (wert|status) (vom|von dem)  (thermostat|) {entity} (bitte|).
+(was ist|wie ist|sag mir) (den|der|) (wert|status) (vom|von dem) {entity} (bitte|).

--- a/vocab/de-de/sensor.intent
+++ b/vocab/de-de/sensor.intent
@@ -1,1 +1,1 @@
-(was ist|wie ist|sag mir) (den|der|) (wert|status) (vom|von dem|von) {entity} (bitte|).
+(was ist|wie ist|sag mir) (den|der|die|das|) (temperatur|farbe|helligkeit|position|wert|status) (vom|von dem|von) {entity} (bitte|).

--- a/vocab/de-de/sensor.intent
+++ b/vocab/de-de/sensor.intent
@@ -1,1 +1,1 @@
-(was ist|wie ist|sag mir) (den|der|) (wert|status) (vom|von dem) {entity} (bitte|).
+(was ist|wie ist|sag mir) (den|der|) (wert|status) (vom|von dem|von) {entity} (bitte|).

--- a/vocab/de-de/sensor.intent
+++ b/vocab/de-de/sensor.intent
@@ -1,1 +1,1 @@
-(was ist|wie ist|sag mir) (den|der|die|das|) (temperatur|farbe|helligkeit|position|wert|status) (vom|von dem|von) {entity} (bitte|).
+(was ist|wie ist|sag mir) (den|der|die|das|) (temperatur|farbe|helligkeit|wert|status) (vom|von dem|von) {entity} (bitte|).

--- a/vocab/en-us/sensor.intent
+++ b/vocab/en-us/sensor.intent
@@ -1,2 +1,1 @@
-(What is|Give me|Tell me) (the|) (value|state|status|read out) of thermostat {Entity} (please|).
 (What is|Give me|Tell me) (the|) (value|state|status|read out) of {Entity} (please|).

--- a/vocab/en-us/sensor.intent
+++ b/vocab/en-us/sensor.intent
@@ -1,1 +1,1 @@
-(What is|Give me|Tell me) (the|) (temperature|hue|brightness|position|value|state|status|read out) of {Entity} (please|).
+(What is|Give me|Tell me) (the|) (temperature|hue|brightness|value|state|status|read out) of {Entity} (please|).

--- a/vocab/en-us/sensor.intent
+++ b/vocab/en-us/sensor.intent
@@ -1,1 +1,1 @@
-(What is|Give me|Tell me) (the|) (value|state|status|read out) of {Entity} (please|).
+(What is|Give me|Tell me) (the|) (temperature|hue|brightness|position|value|state|status|read out) of {Entity} (please|).

--- a/vocab/fr-fr/sensor.intent
+++ b/vocab/fr-fr/sensor.intent
@@ -1,2 +1,1 @@
-(quelle est|indique-moi|dit moi|donne-moi) (le|la|l') (valeure|état|status) du thermostat {Entity} (s'il te plaît|).
 (quelle est|indique-moi|dit moi|donne-moi) (le|la|l') (valeure|état|status) (de|du) {Entity} (s'il te plaît|).

--- a/vocab/it-it/sensor.intent
+++ b/vocab/it-it/sensor.intent
@@ -1,1 +1,1 @@
-(dammi|dimmi|leggi) (lo|il|la) (stato|lettura|valore) (di|del|della) (termostato|) {Entity} (per favore|)
+(dammi|dimmi|leggi) (lo|il|la) (stato|lettura|valore) (di|del|della) {Entity} (per favore|)


### PR DESCRIPTION
#### Description
Remove optional `thermostat` keyword from `sensor.intent` to:

* have a consistent wording
  * was not part of all translations
  * it was the only existant sensor, that was directly named
* a lot of people do prefix their thermostats like "thermostat kitchen", in this case you have to use "the value of thermostat thermostat kitchen"

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
_Either delete those that do not apply, or add an x between the square brackets like so: `- [x]`_
- [X] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements