### PR TITLE
Fix workflow run on PR's

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,3 @@
+# Add label workflow when code changed in ./github
+workflow:
+  - any: ['.github/**/*' ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,15 +7,31 @@ on:
   push:
     branches-ignore:
       - gh-pages
-  pull_request:
+  pull_request_target:
+    types: [labeled]
     branches-ignore:
       - gh-pages
 
 jobs:
-  job-vm:
-
+  safeguard:
     runs-on: ubuntu-latest
+    # Run workflow only when triggered by push (to original repo) or RP from fork when labeled with "secure"
+    # Label will be removed in the beginning  of execution
+    if: contains(github.event.pull_request.labels.*.name, 'secure') || ${{ github.event_name == 'push' }}
 
+    steps:
+      # Remove label "secure" from PR - Prevent running workflow on another commit to PR
+      # After review of new commit, another run can be triggered by adding "secure" label again
+      - name: Github Actions | Remove secure label on PR
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: 'secure'
+        if: ${{ github.event_name == 'pull_request_target' }}
+
+  build:
+    # Run only when safeguard job passed
+    needs: safeguard
+    runs-on: ubuntu-latest
     env:
         HASS_SERVER: http://127.0.0.1:8123
         HASS_TOKEN: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiIyMDY0YjI0YzgyYzY0Y2Q1ODU0ZmRlN2M5ODAyMjVhOCIsImlhdCI6MTYzMzg1NTkxNCwiZXhwIjoxOTQ5MjE1OTE0fQ.wMJ60s8bGe7ygk_xvtnxRixBIYthrCWZyfBKn4e9wdU
@@ -26,271 +42,281 @@ jobs:
         HA_VIRTUAL_VERSION: v0.7.2
 
     steps:
-    - uses: actions/checkout@v2
+      # Use standard checkout if workflow triggered by push
+      - name: Github Actions | Running on commit workflow - push
+        uses: actions/checkout@v2
+        if: ${{ github.event_name == 'push' }}
 
-    # Setup python
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.7
+      # Checkout to PR if workflow triggered by pull_request_target
+      - name: Github Actions | Running on commit workflow - pull_request
+        uses: actions/checkout@v2
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+        if: ${{ github.event_name == 'pull_request_target' }}
 
-    #######################################################################################
-    # Section with prerequisite installations
+      - name: Github Actions | Set up Python 3.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
 
-    - name: Github Actions - Get path to python
-      run: echo "PATH_TO_PYTHON=$(which python)" >> $GITHUB_ENV
+      #######################################################################################
+      # Section with prerequisite installations
 
-    - name: Github Actions - Get repository name
-      run: echo "REPOSITORY_NAME=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')" >> $GITHUB_ENV
-      shell: bash
+      - name: Github Actions - Get path to python
+        run: echo "PATH_TO_PYTHON=$(which python)" >> $GITHUB_ENV
 
-    - name: Home Assistant - Install pip dependencies
-      run: |
-        pip install allure-behave
+      - name: Github Actions - Get repository name
+        run: echo "REPOSITORY_NAME=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')" >> $GITHUB_ENV
+        shell: bash
 
-    - name: Mycroft - Copy skill to Mycroft
-      run: |
-        mkdir -p /opt/mycroft/skills/homeassistant.mycroftai
-        cp -R ${{ github.workspace }}/* /opt/mycroft/skills/homeassistant.mycroftai
-        ls -al /opt/mycroft/skills/homeassistant.mycroftai
-        cp ${{ github.workspace }}/test/ci/Mycroft/settings.json /opt/mycroft/skills/homeassistant.mycroftai/
+      - name: Home Assistant - Install pip dependencies
+        run: |
+          pip install allure-behave
 
-    - name: Mycroft - install Mycroft
-      run: |
-        sudo apt update
-        git clone https://github.com/MycroftAI/mycroft-core.git /opt/mycroft-core
-        ls /opt
-        chmod +x /opt/mycroft-core/dev_setup.sh
-        /opt/mycroft-core/dev_setup.sh --allow-root -ci -sm -p ${{ env.PATH_TO_PYTHON }}
-        source ${{ env.MYCROFT_VENV }}
-        /opt/mycroft-core/bin/mycroft-pip install -r ${{ github.workspace }}/requirements.txt
-        /opt/mycroft-core/bin/mycroft-config set tts.module dummy
-        /opt/mycroft-core/bin/mycroft-start all
+      - name: Mycroft - Copy skill to Mycroft
+        run: |
+          mkdir -p /opt/mycroft/skills/homeassistant.mycroftai
+          cp -R ${{ github.workspace }}/* /opt/mycroft/skills/homeassistant.mycroftai
+          ls -al /opt/mycroft/skills/homeassistant.mycroftai
+          cp ${{ github.workspace }}/test/ci/Mycroft/settings.json /opt/mycroft/skills/homeassistant.mycroftai/
 
-    - name: Mycroft - Remove pairing skill
-      run: /opt/mycroft-core/bin/mycroft-msm remove mycroft-pairing
-      continue-on-error: true
+      - name: Mycroft - install Mycroft
+        run: |
+          sudo apt update
+          git clone https://github.com/MycroftAI/mycroft-core.git /opt/mycroft-core
+          ls /opt
+          chmod +x /opt/mycroft-core/dev_setup.sh
+          /opt/mycroft-core/dev_setup.sh --allow-root -ci -sm -p ${{ env.PATH_TO_PYTHON }}
+          source ${{ env.MYCROFT_VENV }}
+          /opt/mycroft-core/bin/mycroft-pip install -r ${{ github.workspace }}/requirements.txt
+          /opt/mycroft-core/bin/mycroft-config set tts.module dummy
+          /opt/mycroft-core/bin/mycroft-start all
 
-    - name: Github Actions - Install workflow dependencies
-      run: |
-        source ${{ env.MYCROFT_VENV }}
-        pip install allure-behave
-        pip install allure-pytest
-        pip install pylint
+      - name: Mycroft - Remove pairing skill
+        run: /opt/mycroft-core/bin/mycroft-msm remove mycroft-pairing
+        continue-on-error: true
 
-    - name: Home Assistant - get hass virtual component
-      run: git clone --depth 1 --branch ${{ env.HA_VIRTUAL_VERSION }} https://github.com/twrecked/hass-virtual.git /tmp/hass-virtual
+      - name: Github Actions - Install workflow dependencies
+        run: |
+          source ${{ env.MYCROFT_VENV }}
+          pip install allure-behave
+          pip install allure-pytest
+          pip install pylint
 
-    - name: Home Assistant - pull and start docker image
-      run: |
-        docker pull homeassistant/home-assistant:${{ env.HA_VERSION }}
-        docker run -d -p 127.0.0.1:8123:8123 --name="home-assistant" -v ${{ github.workspace }}/test/ci/HA/:/config -v /tmp/hass-virtual/custom_components:/config/custom_components -v /etc/localtime:/etc/localtime:ro homeassistant/home-assistant:${{ env.HA_VERSION }}
+      - name: Home Assistant - get hass virtual component
+        run: git clone --depth 1 --branch ${{ env.HA_VIRTUAL_VERSION }} https://github.com/twrecked/hass-virtual.git /tmp/hass-virtual
 
-    - name: Home Assistant - Install cli
-      run: pip install homeassistant-cli
+      - name: Home Assistant - pull and start docker image
+        run: |
+          docker pull homeassistant/home-assistant:${{ env.HA_VERSION }}
+          docker run -d -p 127.0.0.1:8123:8123 --name="home-assistant" -v ${{ github.workspace }}/test/ci/HA/:/config -v /tmp/hass-virtual/custom_components:/config/custom_components -v /etc/localtime:/etc/localtime:ro homeassistant/home-assistant:${{ env.HA_VERSION }}
 
-    - name: Home Assistant - Set cli
-      run: source <(hass-cli completion bash)
+      - name: Home Assistant - Install cli
+        run: pip install homeassistant-cli
 
-    - name: Home Assistant - Show base info
-      run: hass-cli info
+      - name: Home Assistant - Set cli
+        run: source <(hass-cli completion bash)
 
-    - name: Home Assistant - Show states
-      run: hass-cli state list
+      - name: Home Assistant - Show base info
+        run: hass-cli info
 
-    #######################################################################################
-    # Section with unittests - bust run before VK tests
+      - name: Home Assistant - Show states
+        run: hass-cli state list
 
-    - name: Unittest - Run with output to Allure report
-      id: unittest
-      run: |
-        source /opt/mycroft-core/.venv/bin/activate
-        py.test --alluredir=${{ github.workspace }}/allure_results
-      env:
-        HASS_TOKEN: ${{ env.HASS_TOKEN }}
-      continue-on-error: true
+      #######################################################################################
+      # Section with unittests - bust run before VK tests
 
-    #######################################################################################
-    # Section with VK tests
+      - name: Unittest - Run with output to Allure report
+        id: unittest
+        run: |
+          source /opt/mycroft-core/.venv/bin/activate
+          py.test --alluredir=${{ github.workspace }}/allure_results
+        env:
+          HASS_TOKEN: ${{ env.HASS_TOKEN }}
+        continue-on-error: true
 
-    - name: Mycroft - Clear VKtest
-      run: /opt/mycroft-core/bin/mycroft-skill-testrunner vktest clear
+      #######################################################################################
+      # Section with VK tests
 
-    - name: Mycroft - Run VKtest
-      run: /opt/mycroft-core/bin/mycroft-skill-testrunner vktest -t homeassistant.mycroftai -f allure_behave.formatter:AllureFormatter -o ${{ github.workspace }}/allure_results
+      - name: Mycroft - Clear VKtest
+        run: /opt/mycroft-core/bin/mycroft-skill-testrunner vktest clear
 
-     #######################################################################################
-    # Section with Mycroft logs
+      - name: Mycroft - Run VKtest
+        run: /opt/mycroft-core/bin/mycroft-skill-testrunner vktest -t homeassistant.mycroftai -f allure_behave.formatter:AllureFormatter -o ${{ github.workspace }}/allure_results
 
-    - name: Mycroft - Create directory for logs
-      run: mkdir -p ${{ github.workspace }}/allure-history/${{ github.run_number }}
-      if: always()
+      #######################################################################################
+      # Section with Mycroft logs
 
-    - name: Mycroft - Copy logs
-      run: if [[ -d /var/log/mycroft ]]; then cp -r /var/log/mycroft ${{ github.workspace }}/allure-history/${{ github.run_number }}/; fi
-      shell: bash
+      - name: Mycroft - Create directory for logs
+        run: mkdir -p ${{ github.workspace }}/allure-history/${{ github.run_number }}
+        if: always()
 
-    #######################################################################################
-    # Section with Allure report
+      - name: Mycroft - Copy logs
+        run: if [[ -d /var/log/mycroft ]]; then cp -r /var/log/mycroft ${{ github.workspace }}/allure-history/${{ github.run_number }}/; fi
+        shell: bash
 
-    - name: Github Pages - Pull GH history
-      uses: actions/checkout@v2
-      if: always()
-      continue-on-error: true
-      with:
-        path: ${{ github.workspace }}/gh-pages
-        ref: gh-pages
+      #######################################################################################
+      # Section with Allure report
 
-    - name: Allure - Generate report
-      uses: simple-elf/allure-report-action@master
-      id: allure-report
-      if: always()
-      with:
-        allure_results: ${{ github.workspace }}/allure_results
-        gh_pages: gh-pages
-        allure_report: allure-report
-        allure_history: allure-history
+      - name: Github Pages - Pull GH history
+        uses: actions/checkout@v2
+        if: always()
+        continue-on-error: true
+        with:
+          path: ${{ github.workspace }}/gh-pages
+          ref: gh-pages
 
-    - name: Github Pages - publish results
-      if: always()
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ${{ github.workspace }}/allure-history
-        PUBLISH_BRANCH: gh-pages
+      - name: Allure - Generate report
+        uses: simple-elf/allure-report-action@master
+        id: allure-report
+        if: always()
+        with:
+          allure_results: ${{ github.workspace }}/allure_results
+          gh_pages: gh-pages
+          allure_report: allure-report
+          allure_history: allure-history
 
-    #######################################################################################
-    # Section with publish status links
+      - name: Github Pages - publish results
+        if: always()
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ${{ github.workspace }}/allure-history
+          PUBLISH_BRANCH: gh-pages
 
-    - name: State - Publish Unit/VK test
-      if: always()
-      uses: Sibz/github-status-action@v1
-      with:
-        authToken: ${{ secrets.GITHUB_TOKEN }}
-        context: 'Unit/VK Test report generated'
-        state: ${{ steps.allure-report.outcome }}
-        sha: ${{github.event.pull_request.head.sha || github.sha}}
-        target_url: https://${{ github.repository_owner	}}.github.io/${{ env.REPOSITORY_NAME }}/${{ github.run_number }}/
+      #######################################################################################
+      # Section with publish status links
 
-    - name: State - Publish Mycroft logs
-      if: always()
-      uses: Sibz/github-status-action@v1
-      with:
-        authToken: ${{ secrets.GITHUB_TOKEN }}
-        context: 'Mycroft logs'
-        state: success
-        sha: ${{github.event.pull_request.head.sha || github.sha}}
-        target_url: https://github.com/${{ github.repository }}/tree/gh-pages/${{ github.run_number }}/mycroft/
+      - name: State - Publish Unit/VK test
+        if: always()
+        uses: Sibz/github-status-action@v1
+        with:
+          authToken: ${{ secrets.GITHUB_TOKEN }}
+          context: 'Unit/VK Test report generated'
+          state: ${{ steps.allure-report.outcome }}
+          sha: ${{github.event.pull_request.head.sha || github.sha}}
+          target_url: https://${{ github.repository_owner	}}.github.io/${{ env.REPOSITORY_NAME }}/${{ github.run_number }}/
 
-    #######################################################################################
-    # Section with Linters - keep short names
+      - name: State - Publish Mycroft logs
+        if: always()
+        uses: Sibz/github-status-action@v1
+        with:
+          authToken: ${{ secrets.GITHUB_TOKEN }}
+          context: 'Mycroft logs'
+          state: success
+          sha: ${{github.event.pull_request.head.sha || github.sha}}
+          target_url: https://github.com/${{ github.repository }}/tree/gh-pages/${{ github.run_number }}/mycroft/
 
-    - name: pylint
-      if: always()
-      id: pylint
-      run: |
-        source $MYCROFT_VENV
-        pylint .
+      #######################################################################################
+      # Section with Linters - keep short names
 
-    - name: pycodestyle
-      if: always()
-      uses: ricardochaves/python-lint@v1.4.0
-      id: pycodestyle
-      with:
-        use-pylint: false
-        use-pycodestyle: true
-        use-flake8: false
-        use-black: false
-        use-mypy: false
-        use-isort: false
-        extra-pycodestyle-options: "--max-line-length=${{ env.MAX_LINE_LENGTH }}"
+      - name: pylint
+        if: always()
+        id: pylint
+        run: |
+          source $MYCROFT_VENV
+          pylint --max-line-length=${{ env.MAX_LINE_LENGTH }} .
 
-    - name: flake8
-      if: always()
-      uses: ricardochaves/python-lint@v1.4.0
-      id: flake8
-      with:
-        use-pylint: false
-        use-pycodestyle: false
-        use-flake8: true
-        use-black: false
-        use-mypy: false
-        use-isort: false
-        extra-flake8-options: "--max-line-length=${{ env.MAX_LINE_LENGTH }}"
+      - name: pycodestyle
+        if: always()
+        uses: ricardochaves/python-lint@v1.4.0
+        id: pycodestyle
+        with:
+          use-pylint: false
+          use-pycodestyle: true
+          use-flake8: false
+          use-black: false
+          use-mypy: false
+          use-isort: false
+          extra-pycodestyle-options: "--max-line-length=${{ env.MAX_LINE_LENGTH }}"
 
-    - name: isort
-      if: always()
-      uses: ricardochaves/python-lint@v1.4.0
-      id: isort
-      with:
-        use-pylint: false
-        use-pycodestyle: false
-        use-flake8: false
-        use-black: false
-        use-mypy: false
-        use-isort: true
-        extra-isort-options: ""
+      - name: flake8
+        if: always()
+        uses: ricardochaves/python-lint@v1.4.0
+        id: flake8
+        with:
+          use-pylint: false
+          use-pycodestyle: false
+          use-flake8: true
+          use-black: false
+          use-mypy: false
+          use-isort: false
+          extra-flake8-options: "--max-line-length=${{ env.MAX_LINE_LENGTH }}"
 
-    #######################################################################################
-    # Section with Publish state of Linters
+      - name: isort
+        if: always()
+        uses: ricardochaves/python-lint@v1.4.0
+        id: isort
+        with:
+          use-pylint: false
+          use-pycodestyle: false
+          use-flake8: false
+          use-black: false
+          use-mypy: false
+          use-isort: true
+          extra-isort-options: ""
 
-    - name: State - Get step id for accessing step status logs
-      id: linters_status
-      if: always()
-      run: |
-        JOBS=$(curl -H "Accept: application/vnd.github.v3+json" ${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs | jq -r '.jobs')
-        for row in $(echo "${JOBS}" | jq -r '.[] | @base64'); do
-            _jq() {
-              echo "${row}" | base64 --decode | jq -r ${1}
-            }
-            if [ $(echo "$( _jq '.name')") = "${GITHUB_JOB}" ]; then
-              echo "LOG_ID=$(_jq '.id')" >> $GITHUB_ENV
-              for step in $(echo "$(_jq '.steps')" | jq -r '.[] | @base64'); do
-                _jqs() {
-                echo "${step}" | base64 --decode | jq -r ${1}
+      #######################################################################################
+      # Section with Publish state of Linters
+
+      - name: State - Get step id for accessing step status logs
+        id: linters_status
+        if: always()
+        run: |
+          JOBS=$(curl -H "Accept: application/vnd.github.v3+json" ${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs | jq -r '.jobs')
+          for row in $(echo "${JOBS}" | jq -r '.[] | @base64'); do
+              _jq() {
+                echo "${row}" | base64 --decode | jq -r ${1}
               }
-              echo "::set-output name=$(_jqs '.name')::$(_jqs '.number')"
-              echo "$(_jqs '.name'):$(_jqs '.number')"
-              done
-            fi
-        done
+              if [ $(echo "$( _jq '.name')") = "${GITHUB_JOB}" ]; then
+                echo "LOG_ID=$(_jq '.id')" >> $GITHUB_ENV
+                for step in $(echo "$(_jq '.steps')" | jq -r '.[] | @base64'); do
+                  _jqs() {
+                  echo "${step}" | base64 --decode | jq -r ${1}
+                }
+                echo "::set-output name=$(_jqs '.name')::$(_jqs '.number')"
+                echo "$(_jqs '.name'):$(_jqs '.number')"
+                done
+              fi
+          done
 
-    - name: State - pylint
-      if: always()
-      uses: Sibz/github-status-action@v1
-      with:
-        authToken: ${{ secrets.GITHUB_TOKEN }}
-        context: 'pylint'
-        state: ${{ steps.pylint.outcome }}
-        sha: ${{github.event.pull_request.head.sha || github.sha}}
-        target_url: https://github.com/${{ github.repository }}/runs/${{ env.LOG_ID }}#step:${{ steps.linters_status.outputs.pylint }}:1
+      - name: State - pylint
+        if: always()
+        uses: Sibz/github-status-action@v1
+        with:
+          authToken: ${{ secrets.GITHUB_TOKEN }}
+          context: 'pylint'
+          state: ${{ steps.pylint.outcome }}
+          sha: ${{github.event.pull_request.head.sha || github.sha}}
+          target_url: https://github.com/${{ github.repository }}/runs/${{ env.LOG_ID }}#step:${{ steps.linters_status.outputs.pylint }}:1
 
-    - name: State - pycodestyle
-      if: always()
-      uses: Sibz/github-status-action@v1
-      with:
-        authToken: ${{ secrets.GITHUB_TOKEN }}
-        context: 'pycodestyle'
-        state: ${{ steps.pycodestyle.outcome }}
-        sha: ${{github.event.pull_request.head.sha || github.sha}}
-        target_url: https://github.com/${{ github.repository }}/runs/${{ env.LOG_ID }}#step:${{ steps.linters_status.outputs.pycodestyle }}:1
+      - name: State - pycodestyle
+        if: always()
+        uses: Sibz/github-status-action@v1
+        with:
+          authToken: ${{ secrets.GITHUB_TOKEN }}
+          context: 'pycodestyle'
+          state: ${{ steps.pycodestyle.outcome }}
+          sha: ${{github.event.pull_request.head.sha || github.sha}}
+          target_url: https://github.com/${{ github.repository }}/runs/${{ env.LOG_ID }}#step:${{ steps.linters_status.outputs.pycodestyle }}:1
 
-    - name: State - flake8
-      if: always()
-      uses: Sibz/github-status-action@v1
-      with:
-        authToken: ${{ secrets.GITHUB_TOKEN }}
-        context: 'flake8'
-        state: ${{ steps.flake8.outcome }}
-        sha: ${{github.event.pull_request.head.sha || github.sha}}
-        target_url: https://github.com/${{ github.repository }}/runs/${{ env.LOG_ID }}#step:${{ steps.linters_status.outputs.flake8 }}:1
+      - name: State - flake8
+        if: always()
+        uses: Sibz/github-status-action@v1
+        with:
+          authToken: ${{ secrets.GITHUB_TOKEN }}
+          context: 'flake8'
+          state: ${{ steps.flake8.outcome }}
+          sha: ${{github.event.pull_request.head.sha || github.sha}}
+          target_url: https://github.com/${{ github.repository }}/runs/${{ env.LOG_ID }}#step:${{ steps.linters_status.outputs.flake8 }}:1
 
-    - name: State - isort
-      if: always()
-      uses: Sibz/github-status-action@v1
-      with:
-        authToken: ${{ secrets.GITHUB_TOKEN }}
-        context: 'isort'
-        state: ${{ steps.isort.outcome }}
-        sha: ${{github.event.pull_request.head.sha || github.sha}}
-        target_url: https://github.com/${{ github.repository }}/runs/${{ env.LOG_ID }}#step:${{ steps.linters_status.outputs.isort }}:1
+      - name: State - isort
+        if: always()
+        uses: Sibz/github-status-action@v1
+        with:
+          authToken: ${{ secrets.GITHUB_TOKEN }}
+          context: 'isort'
+          state: ${{ steps.isort.outcome }}
+          sha: ${{github.event.pull_request.head.sha || github.sha}}
+          target_url: https://github.com/${{ github.repository }}/runs/${{ env.LOG_ID }}#step:${{ steps.linters_status.outputs.isort }}:1

--- a/.github/workflows/workflow_check.yml
+++ b/.github/workflows/workflow_check.yml
@@ -1,0 +1,13 @@
+# Workflow checker -  check for changes inside .github folder, if found apply label workflow.
+
+name: "Workflow checker"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: tony763/labeler@v3.0.3    # For now use this as original action does not support hidden files
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
#### Description
Workflows runs triggered by `pull_request` event does not have write access to repository so status updates and upload to GitHub Pages does not work.

Write access can be gain when event for triggering workflow is set to  `pull_request_target`, but it could be potentially unsafe as anybody could implement malicious code into code but not into workflow as it is run from repository not from commit. Any change to workflow is not use, when this event trigger it.

To make PRs working and secure I added these:
Workflow can be triggered by `pull` or  `pull_request_target`.
- Workflow triggered by event `pull` are run immediately.
- Workflow triggered by event `pull_request_target` are run only when label:  `secure` is added.

#### Workflow is divided to two jobs:
#### `safeguard`: 
 - Check if event is `push` or pull request contain label `secure`
 - If pull request, bot will remove `secure` label from PR
 
#### `build`:
 - Runs only when `safeguard` passes with ok state
 - do all tests and uploads as before

With those changes, when new PR is issued, no test runs.
Only when maintainer check changes and place label `secure` to it,
workflow start. If new commit is added to PR, no run is triggered until label
`secure` is added again.

When a change to workflow is proposed, its a better to check it's outcome in forked repository. 

For contributors there is still possibility to run workflow on their forks, so they can do changes and test them on them.

#### Type of PR
- [x] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Big thanks to @pfefferle for help with testing.

