### PR TITLE
Add function to list tracker entities and register them.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -129,7 +129,7 @@ class HomeAssistantSkill(FallbackSkill):
     # Creates dialogs for errors and speaks them
     # Returns None if nothing was found
     # Else returns entity that was found
-    def _find_entity(self, entity: str, domains: list(str)) -> dict:
+    def _find_entity(self, entity: str, domains: list) -> dict:
         """Handle communication with HA client for entity finding
 
         Returns:

--- a/__init__.py
+++ b/__init__.py
@@ -4,8 +4,8 @@ Home Assistant skill
 from os.path import join as pth_join
 
 from mycroft import MycroftSkill, intent_handler
-from mycroft.skills.core import FallbackSkill
 from mycroft.messagebus.message import Message
+from mycroft.skills.core import FallbackSkill
 from mycroft.util import get_cache_directory
 from mycroft.util.format import nice_number
 from quantulum3 import parser

--- a/__init__.py
+++ b/__init__.py
@@ -5,6 +5,7 @@ from os.path import join as pth_join
 
 from mycroft import MycroftSkill, intent_handler
 from mycroft.skills.core import FallbackSkill
+from mycroft.messagebus.message import Message
 from mycroft.util import get_cache_directory
 from mycroft.util.format import nice_number
 from quantulum3 import parser
@@ -25,13 +26,13 @@ TIMEOUT = 10
 class HomeAssistantSkill(FallbackSkill):
     """Main skill class"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         MycroftSkill.__init__(self)
         super().__init__(name="HomeAssistantSkill")
         self.ha_client = None
         self.enable_fallback = False
 
-    def _setup(self, force=False):
+    def _setup(self, force: bool = False) -> None:
         if self.settings is not None and (force or self.ha_client is None):
             # Check if user filled IP, port and Token in configuration
             ip_address = check_url(str(self.settings.get('host')))
@@ -82,11 +83,11 @@ class HomeAssistantSkill(FallbackSkill):
                 # Register tracker entities
                 self._register_tracker_entities()
 
-    def _force_setup(self):
+    def _force_setup(self) -> None:
         self.log.debug('Creating a new HomeAssistant-Client')
         self._setup(True)
 
-    def _register_tracker_entities(self):
+    def _register_tracker_entities(self) -> None:
         """List tracker entities.
 
         Add them to entity file and registry it so
@@ -105,7 +106,7 @@ class HomeAssistantSkill(FallbackSkill):
                 voc_file.write('\n'.join(entities))
             self.register_entity_file(self.tracker_file)
 
-    def initialize(self):
+    def initialize(self) -> None:
         """Initialize skill, set language and priority."""
         # pylint: disable=W0201
         self.language = self.config_core.get('lang')
@@ -117,7 +118,7 @@ class HomeAssistantSkill(FallbackSkill):
         self.settings_change_callback = self.on_websettings_changed
         self._setup()
 
-    def on_websettings_changed(self):
+    def on_websettings_changed(self) -> None:
         """
         Force a setting refresh after the websettings changed
         otherwise new settings will not be regarded.
@@ -128,7 +129,12 @@ class HomeAssistantSkill(FallbackSkill):
     # Creates dialogs for errors and speaks them
     # Returns None if nothing was found
     # Else returns entity that was found
-    def _find_entity(self, entity, domains):
+    def _find_entity(self, entity: str, domains: list(str)) -> dict:
+        """Handle communication with HA client for entity finding
+
+        Returns:
+            Entity
+        """
         self._setup()
         if self.ha_client is None:
             self.speak_dialog('homeassistant.error.setup')
@@ -142,10 +148,13 @@ class HomeAssistantSkill(FallbackSkill):
                               "dev_name": entity})
         return ha_entity
 
-    # Routine for entity availability check
-    def _check_availability(self, ha_entity):
+    def _check_availability(self, ha_entity: dict) -> bool:
         """ Simple routine for checking availability of entity inside
-        Home Assistant. """
+        Home Assistant.
+
+        Returns:
+            True/False state
+        """
 
         if ha_entity['state'] == 'unavailable':
             """Check if state is unavailable, if yes, inform user about it."""
@@ -156,8 +165,11 @@ class HomeAssistantSkill(FallbackSkill):
             return False
         return True
 
-    # Calls passed method and catches often occurring exceptions
     def _handle_client_exception(self, callback, *args, **kwargs):
+        """Calls passed method and catches often occurring exceptions
+
+        Returns:
+            Function output or False"""
         try:
             return callback(*args, **kwargs)
         except Timeout:
@@ -188,7 +200,7 @@ class HomeAssistantSkill(FallbackSkill):
 
     # Intent handlers
     @intent_handler('turn.on.intent')
-    def handle_turn_on_intent(self, message):
+    def handle_turn_on_intent(self, message: Message) -> None:
         """Handle turn on intent."""
         self.log.debug("Turn on intent on entity: %s", message.data.get("entity"))
         message.data["Entity"] = message.data.get("entity")
@@ -196,7 +208,7 @@ class HomeAssistantSkill(FallbackSkill):
         self._handle_turn_actions(message)
 
     @intent_handler('turn.off.intent')
-    def handle_turn_off_intent(self, message):
+    def handle_turn_off_intent(self, message: Message) -> None:
         """Handle turn off intent."""
         self.log.debug("Turn off intent on entity: %s", message.data.get("entity"))
         message.data["Entity"] = message.data.get("entity")
@@ -204,28 +216,28 @@ class HomeAssistantSkill(FallbackSkill):
         self._handle_turn_actions(message)
 
     @intent_handler('open.intent')
-    def handle_open(self, message):
+    def handle_open(self, message: Message) -> None:
         """Handle open intent."""
         message.data["Entity"] = message.data.get("entity")
         message.data["Action"] = "open"
         self._handle_open_close_actions(message)
 
     @intent_handler('close.intent')
-    def handle_close(self, message):
+    def handle_close(self, message: Message) -> None:
         """Handle close intent."""
         message.data["Entity"] = message.data.get("entity")
         message.data["Action"] = "close"
         self._handle_open_close_actions(message)
 
     @intent_handler('stop.intent')
-    def handle_stop(self, message):
+    def handle_stop(self, message: Message) -> None:
         """Handle stop intent."""
         message.data["Entity"] = message.data.get("entity")
         message.data["Action"] = "stop"
         self._handle_stop_actions(message)
 
     @intent_handler('toggle.intent')
-    def handle_toggle_intent(self, message):
+    def handle_toggle_intent(self, message: Message) -> None:
         """Handle toggle intent."""
         self.log.debug("Toggle intent on entity: %s", message.data.get("entity"))
         message.data["Entity"] = message.data.get("entity")
@@ -233,14 +245,14 @@ class HomeAssistantSkill(FallbackSkill):
         self._handle_turn_actions(message)
 
     @intent_handler('sensor.intent')
-    def handle_sensor_intent(self, message):
+    def handle_sensor_intent(self, message: Message) -> None:
         """Handle sensor intent."""
         self.log.debug("Turn on intent on entity: %s", message.data.get("entity"))
         message.data["Entity"] = message.data.get("entity")
         self._handle_sensor(message)
 
     @intent_handler('set.light.brightness.intent')
-    def handle_light_set_intent(self, message):
+    def handle_light_set_intent(self, message: Message) -> None:
         """Handle set light brightness intent."""
         self.log.debug("Change light intensity: %s to %s percent", message.data.get("entity"),
                        message.data.get("brightnessvalue"))
@@ -249,7 +261,7 @@ class HomeAssistantSkill(FallbackSkill):
         self._handle_light_set(message)
 
     @intent_handler('increase.light.brightness.intent')
-    def handle_light_increase_intent(self, message):
+    def handle_light_increase_intent(self, message: Message) -> None:
         """Handle increase light brightness intent."""
         self.log.debug("Increase light intensity: %s", message.data.get("entity"))
         message.data["Entity"] = message.data.get("entity")
@@ -257,7 +269,7 @@ class HomeAssistantSkill(FallbackSkill):
         self._handle_light_adjust(message)
 
     @intent_handler('decrease.light.brightness.intent')
-    def handle_light_decrease_intent(self, message):
+    def handle_light_decrease_intent(self, message: Message) -> None:
         """Handle decrease light brightness intent."""
         self.log.debug("Decrease light intensity: %s", message.data.get("entity"))
         message.data["Entity"] = message.data.get("entity")
@@ -265,21 +277,21 @@ class HomeAssistantSkill(FallbackSkill):
         self._handle_light_adjust(message)
 
     @intent_handler('automation.intent')
-    def handle_automation_intent(self, message):
+    def handle_automation_intent(self, message: Message) -> None:
         """Handle automation intent."""
         self.log.debug("Automation trigger intent on entity: %s", message.data.get("entity"))
         message.data["Entity"] = message.data.get("entity")
         self._handle_automation(message)
 
     @intent_handler('tracker.intent')
-    def handle_tracker_intent(self, message):
+    def handle_tracker_intent(self, message: Message) -> None:
         """Handle tracker intent."""
         self.log.debug("Turn on intent on entity: %s", message.data.get("tracker"))
         message.data["Entity"] = message.data.get("tracker")
         self._handle_tracker(message)
 
     @intent_handler('set.climate.intent')
-    def handle_set_thermostat_intent(self, message):
+    def handle_set_thermostat_intent(self, message: Message) -> None:
         """Handle set climate intent."""
         self.log.debug("Set thermostat intent on entity: %s", message.data.get("entity"))
         message.data["Entity"] = message.data.get("entity")
@@ -287,13 +299,13 @@ class HomeAssistantSkill(FallbackSkill):
         self._handle_set_thermostat(message)
 
     @intent_handler('add.item.shopping.list.intent')
-    def handle_shopping_list_intent(self, message):
+    def handle_shopping_list_intent(self, message: Message) -> None:
         """Handle add item to shopping list intent."""
         self.log.debug("Add %s to the shoping list", message.data.get("entity"))
         message.data["Entity"] = message.data.get("entity")
         self._handle_shopping_list(message)
 
-    def _handle_turn_actions(self, message):
+    def _handle_turn_actions(self, message: Message) -> None:
         """Handler for turn on/off and toggle actions."""
         self.log.debug("Starting Switch Intent")
         entity = message.data["Entity"]
@@ -370,7 +382,7 @@ class HomeAssistantSkill(FallbackSkill):
             self.speak_dialog('homeassistant.error.sorry')
             return
 
-    def _handle_light_set(self, message):
+    def _handle_light_set(self, message: Message) -> None:
         """Handle set light action."""
         entity = message.data["entity"]
         try:
@@ -405,14 +417,14 @@ class HomeAssistantSkill(FallbackSkill):
 
         return
 
-    def _handle_shopping_list(self, message):
+    def _handle_shopping_list(self, message: Message) -> None:
         """Handler for add item to shopping list action."""
         entity = message.data["Entity"]
         ha_data = {'name': entity}
         self.ha_client.execute_service("shopping_list", "add_item", ha_data)
         self.speak_dialog("homeassistant.shopping.list")
 
-    def _handle_open_close_actions(self, message):
+    def _handle_open_close_actions(self, message: Message) -> None:
         """Handler for open and close actions."""
         entity = message.data["Entity"]
         action = message.data["Action"]
@@ -483,7 +495,7 @@ class HomeAssistantSkill(FallbackSkill):
 
         return
 
-    def _handle_light_adjust(self, message):
+    def _handle_light_adjust(self, message: Message) -> None:
         """Handler for light brightness increase and decrease action"""
         entity = message.data["Entity"]
         action = message.data["Action"]
@@ -554,7 +566,7 @@ class HomeAssistantSkill(FallbackSkill):
             self.speak_dialog('homeassistant.error.sorry')
             return
 
-    def _handle_automation(self, message):
+    def _handle_automation(self, message: Message) -> None:
         """Handler for triggering automations."""
         entity = message.data["Entity"]
         self.log.debug("Entity: %s", entity)
@@ -588,7 +600,7 @@ class HomeAssistantSkill(FallbackSkill):
             self.ha_client.execute_service("scene", "turn_on",
                                            data=ha_data)
 
-    def _handle_sensor(self, message):
+    def _handle_sensor(self, message: Message) -> None:
         """Handler sensors reading"""
         entity = message.data["Entity"]
         self.log.debug("Entity: %s", entity)
@@ -605,8 +617,7 @@ class HomeAssistantSkill(FallbackSkill):
             ]
         )
 
-        # Exit if entiti not found or is unavailabe
-
+        # Exit if entity not found or is unavailabe
         if not ha_entity or not self._check_availability(ha_entity):
             return
 
@@ -692,7 +703,7 @@ class HomeAssistantSkill(FallbackSkill):
     # Proximity might be an issue
     # - overlapping command for directions modules
     # - (e.g. "How far is x from y?")
-    def _handle_tracker(self, message):
+    def _handle_tracker(self, message: Message) -> None:
         """Handler for finding trackers position."""
         entity = message.data["Entity"]
         self.log.debug("Entity: %s", entity)
@@ -712,7 +723,7 @@ class HomeAssistantSkill(FallbackSkill):
                           data={'dev_name': dev_name,
                                 'location': dev_location})
 
-    def _handle_set_thermostat(self, message):
+    def _handle_set_thermostat(self, message: Message) -> None:
         """Handler for setting thermostats."""
         entity = message.data["entity"]
         self.log.debug("Entity: %s", entity)
@@ -752,10 +763,13 @@ class HomeAssistantSkill(FallbackSkill):
         self.gui["sensorDescription"] = description
         self.gui.show_page("sensors.qml", override_idle=15)
 
-    def handle_fallback(self, message):
+    def handle_fallback(self, message: Message) -> bool:
         """
         Handler for direct fallback to Home Assistants
         conversation module.
+
+        Returns:
+            True/False state of fallback registration
         """
         if not self.enable_fallback:
             return False
@@ -782,7 +796,7 @@ class HomeAssistantSkill(FallbackSkill):
         self.speak(answer, expect_response=asked_question)
         return True
 
-    def shutdown(self):
+    def shutdown(self) -> None:
         """Remove fallback on exit."""
         self.remove_fallback(self.handle_fallback)
         super().shutdown()

--- a/__init__.py
+++ b/__init__.py
@@ -31,6 +31,7 @@ class HomeAssistantSkill(FallbackSkill):
         super().__init__(name="HomeAssistantSkill")
         self.ha_client = None
         self.enable_fallback = False
+        self.tracker_file = ""
 
     def _setup(self, force: bool = False) -> None:
         if self.settings is not None and (force or self.ha_client is None):
@@ -100,7 +101,6 @@ class HomeAssistantSkill(FallbackSkill):
         if entities:
             cache_dir = get_cache_directory(type(self).__name__)
             self.tracker_file = pth_join(cache_dir, "tracker.entity")
-            self.cache_data()
 
             with open(self.tracker_file, 'w', encoding='utf8') as voc_file:
                 voc_file.write('\n'.join(entities))

--- a/__init__.py
+++ b/__init__.py
@@ -5,6 +5,7 @@ from os.path import join as pth_join
 
 from mycroft import MycroftSkill, intent_handler
 from mycroft.skills.core import FallbackSkill
+from mycroft.util import get_cache_directory
 from mycroft.util.format import nice_number
 from quantulum3 import parser
 from requests.exceptions import (HTTPError, InvalidURL, RequestException,
@@ -79,13 +80,13 @@ class HomeAssistantSkill(FallbackSkill):
                         self.settings.get('enable_fallback')
 
                 # Register tracker entities
-                self._list_tracker_entities()
+                self._register_tracker_entities()
 
     def _force_setup(self):
         self.log.debug('Creating a new HomeAssistant-Client')
         self._setup(True)
 
-    def _list_tracker_entities(self):
+    def _register_tracker_entities(self):
         """List tracker entities.
 
         Add them to entity file and registry it so
@@ -96,10 +97,13 @@ class HomeAssistantSkill(FallbackSkill):
         entities = self.ha_client.list_entities(types)
 
         if entities:
-            entity_file = pth_join(self.root_dir, 'vocab', 'tracker.entity')
-            with open(entity_file, 'w', encoding='utf8') as voc_file:
+            cache_dir = get_cache_directory(type(self).__name__)
+            self.tracker_file = pth_join(cache_dir, "tracker.entity")
+            self.cache_data()
+
+            with open(self.tracker_file, 'w', encoding='utf8') as voc_file:
                 voc_file.write('\n'.join(entities))
-            self.register_entity_file('tracker.entity')
+            self.register_entity_file(self.tracker_file)
 
     def initialize(self):
         """Initialize skill, set language and priority."""

--- a/ha_client.py
+++ b/ha_client.py
@@ -12,7 +12,6 @@ from requests import get, post
 from requests.exceptions import RequestException, Timeout
 from requests.models import Response
 
-
 __author__ = 'btotharye'
 
 # Timeout time for HA requests

--- a/ha_client.py
+++ b/ha_client.py
@@ -199,6 +199,34 @@ class HomeAssistantClient:
                     return entity_attr
         return None
 
+    def list_entities(self, types):
+        """List all entities matching domains used within our skill
+        and return them as list.
+
+        Throws request Exceptions
+        (Subclasses of ConnectionError or RequestException,
+          raises HTTPErrors if non-Ok status code)
+        """
+
+        json_data = self._get_state()
+        entities = []
+        if json_data:
+            for state in json_data:
+                try:
+                    entity_id = state['entity_id'].split(".")
+                    domain = entity_id[0]
+                    entity = entity_id[1]
+                    if domain in types:
+                        """Domain of Entity is in handled types.
+                        Add Entity and its friendly name to list.
+                        """
+                        entities.append(entity)
+                        entities.append(state['attributes']
+                                        ['friendly_name'].lower())
+                except KeyError:
+                    pass
+        return entities
+
     def execute_service(self, domain, service, data):
         """Execute service at HAServer
 

--- a/ha_client.py
+++ b/ha_client.py
@@ -5,7 +5,6 @@ Handle connection between skill and HA instance trough websocket.
 import ipaddress
 import json
 import re
-from typing import List
 
 from fuzzywuzzy import fuzz
 from requests import get, post
@@ -134,7 +133,7 @@ class HomeAssistantClient:
         except (Timeout, ConnectionError, RequestException):
             return False
 
-    def find_entity(self, entity: str, types: list(str)) -> dict:
+    def find_entity(self, entity: str, types: list) -> dict:
         """Find entity with specified name, fuzzy matching
 
         Throws request Exceptions
@@ -220,7 +219,7 @@ class HomeAssistantClient:
                     return entity_attr
         return None
 
-    def list_entities(self, types: List[str]) -> List[str, str]:
+    def list_entities(self, types: list) -> list:
         """List all entities matching domains used within our skill
 
         Throws request Exceptions

--- a/ha_client.py
+++ b/ha_client.py
@@ -5,13 +5,13 @@ Handle connection between skill and HA instance trough websocket.
 import ipaddress
 import json
 import re
-
+from typing import List
 
 from fuzzywuzzy import fuzz
 from requests import get, post
 from requests.exceptions import RequestException, Timeout
 from requests.models import Response
-from typing import Dict, List
+
 
 __author__ = 'btotharye'
 

--- a/test/behave/12_tracker.feature
+++ b/test/behave/12_tracker.feature
@@ -8,10 +8,11 @@ Feature: tracker
   # Intent conflict when asking where something is
   Scenario Outline: where is skill conflict
     Given an English speaking user
-    When the user says  "<where is skill conflict>"
+    When the user says "<cases>"
 	  Then "skill-homeassistant" should not reply
 
   Examples: where is skill conflict
+        | cases |
         | give me location of the Czech Republic |
         | where is France                        |
         | where is the golden gate bridge        |

--- a/test/behave/12_tracker.feature
+++ b/test/behave/12_tracker.feature
@@ -5,12 +5,13 @@ Feature: tracker
     When the user says "give me location of the mark"
 	  Then mycroft reply should contain "home"
 
-  Scenario Outline: where skill conflict>
+  # Intent conflict when asking where something is
+  Scenario Outline: where is skill conflict
     Given an English speaking user
-    When the user says  "<where skill conflict>"
+    When the user says  "<where is skill conflict>"
 	  Then "skill-homeassistant" should not reply
 
-  Examples: where skill conflict
+  Examples: where is skill conflict
         | give me location of the Czech Republic |
         | where is France                        |
         | where is the golden gate bridge        |

--- a/test/behave/12_tracker.feature
+++ b/test/behave/12_tracker.feature
@@ -5,17 +5,13 @@ Feature: tracker
     When the user says "give me location of the mark"
 	  Then mycroft reply should contain "home"
 
-  Scenario: tracker - where skill conflict #1
+  Scenario Outline: where skill conflict>
     Given an English speaking user
-    When the user says "give me location of the Czech Republic"
+    When the user says  "<where skill conflict>"
 	  Then "skill-homeassistant" should not reply
 
-  Scenario: tracker - where skill conflict #2
-    Given an English speaking user
-    When the user says "where is France"
-	  Then "skill-homeassistant" should not reply
-
-  Scenario: tracker - where skill conflict #3
-    Given an English speaking user
-    When the user says "where is the golden gate bridge"
-	  Then "skill-homeassistant" should not reply
+  Examples: where skill conflict
+        | give me location of the Czech Republic |
+        | where is France                        |
+        | where is the golden gate bridge        |
+        | current weather                        |

--- a/test/behave/12_tracker.feature
+++ b/test/behave/12_tracker.feature
@@ -4,3 +4,18 @@ Feature: tracker
     Given an English speaking user
     When the user says "give me location of the mark"
 	  Then mycroft reply should contain "home"
+
+  Scenario: tracker - where skill conflict #1
+    Given an English speaking user
+    When the user says "give me location of the Czech Republic"
+	  Then "skill-homeassistant" should not reply
+
+  Scenario: tracker - where skill conflict #2
+    Given an English speaking user
+    When the user says "where is France"
+	  Then "skill-homeassistant" should not reply
+
+  Scenario: tracker - where skill conflict #3
+    Given an English speaking user
+    When the user says "where is the golden gate bridge"
+	  Then "skill-homeassistant" should not reply

--- a/vocab/cs-cz/tracker.intent
+++ b/vocab/cs-cz/tracker.intent
@@ -1,5 +1,5 @@
-Jaká je pozice {Entity}.
-Kde (je| se nachází) {Entity}.
-Můžeš (prosím|) (najít|vyhledat) {Entity} (please|).
-Rád bych (našel|vyhledal|lokalizoval) {Entity}
+Jaká je pozice {Tracker}.
+Kde (je| se nachází) {Tracker}.
+Můžeš (prosím|) (najít|vyhledat) {Tracker} (prosím|).
+Rád bych (našel|vyhledal|lokalizoval) {Tracker}
 

--- a/vocab/de-de/tracker.intent
+++ b/vocab/de-de/tracker.intent
@@ -1,2 +1,2 @@
-wo ist (der|die|das|) {entity}.
-gib mit den standort von {entity}
+wo ist (der|die|das|) {Tracker}.
+gib mit den standort von {Tracker}

--- a/vocab/en-us/tracker.intent
+++ b/vocab/en-us/tracker.intent
@@ -1,2 +1,2 @@
-Where is (the|) {Entity}.
-(Give|Find) me (location|position) of (the|) {Entity}.
+Where is (the|) {Tracker}.
+(Give|Find) me (location|position) of (the|) {Tracker}.

--- a/vocab/fr-fr/tracker.intent
+++ b/vocab/fr-fr/tracker.intent
@@ -1,2 +1,2 @@
-où se trouve {Entity}.
-(donne|trouve) la (localisation|position) (de|du) {Entity}.
+où se trouve {Tracker}.
+(donne|trouve) la (localisation|position) (de|du) {Tracker}.

--- a/vocab/it-it/tracker.intent
+++ b/vocab/it-it/tracker.intent
@@ -1,2 +1,2 @@
-(Dove|Dov') è (il|la|lo|) {Entity}
-(Dammi|Trova) (la|) (positione) (di|del|della|degli|) {Entity}.
+(Dove|Dov') è (il|la|lo|) {Tracker}
+(Dammi|Trova) (la|) (positione) (di|del|della|degli|) {Tracker}.


### PR DESCRIPTION
#### Description
Added function to get list of tracker entities at connection to HA.
List is saved as `tracker.entity` in `vocab` folder and registered by `register_entity_file()`

Padatious intent for tracker then react only for them.

Should solve conflict with skill `where` aka #64 .

#### Type of PR
- [x] Bugfix
- [x] Feature implementation
- [ ] Refactor of code (without functional changes)
- [x] Documentation improvements
- [x] Test improvements

#### Testing
Added test vk test where skill should not react.
