### PR TITLE
Corrected French imperative verbs

### DIFF
--- a/vocab/fr-fr/ClimateKeyword.voc
+++ b/vocab/fr-fr/ClimateKeyword.voc
@@ -1,1 +1,1 @@
-Défini la température de {entity} à {temperature}
+Définis la température de {entity} à {temperature}

--- a/vocab/fr-fr/DecreaseVerb.voc
+++ b/vocab/fr-fr/DecreaseVerb.voc
@@ -1,2 +1,2 @@
 diminuer
-bas
+baisser

--- a/vocab/fr-fr/DeviceTrackerKeyword.voc
+++ b/vocab/fr-fr/DeviceTrackerKeyword.voc
@@ -1,3 +1,3 @@
-ou est
+où est
 localise|localisation 
-ou
+où

--- a/vocab/fr-fr/IncreaseVerb.voc
+++ b/vocab/fr-fr/IncreaseVerb.voc
@@ -1,2 +1,2 @@
 augmenter
-haut
+élever

--- a/vocab/fr-fr/LightBrightenVerb.voc
+++ b/vocab/fr-fr/LightBrightenVerb.voc
@@ -1,1 +1,1 @@
-éclairci|plus clair|clair|allumé
+éclaircis|plus clair|clair|allumé

--- a/vocab/fr-fr/LightDimVerb.voc
+++ b/vocab/fr-fr/LightDimVerb.voc
@@ -1,1 +1,1 @@
-réduit|réduire|diminue|diminuer|plus bas|plus sombre|sombre|noir
+réduis|réduire|diminue|diminuer|plus bas|plus sombre|sombre|noir

--- a/vocab/fr-fr/SetVerb.voc
+++ b/vocab/fr-fr/SetVerb.voc
@@ -1,1 +1,1 @@
-met
+mets

--- a/vocab/fr-fr/automation.intent
+++ b/vocab/fr-fr/automation.intent
@@ -1,1 +1,1 @@
-(active|allume|enclenche|déclenche|défini) (la|le) (automation|scène|script) {Entity}.
+(active|allume|enclenche|déclenche|définis) (la|le) (automation|scène|script) {Entity}.

--- a/vocab/fr-fr/decrease.light.brightness.intent
+++ b/vocab/fr-fr/decrease.light.brightness.intent
@@ -1,3 +1,3 @@
 baisse (luminosité|intensité) {entity}
 (baisse|diminue) {entity}
-(affaibli|assombri) {entity}
+(affaiblis|assombris) {entity}

--- a/vocab/fr-fr/increase.light.brightness.intent
+++ b/vocab/fr-fr/increase.light.brightness.intent
@@ -1,3 +1,3 @@
 augmente (la|l') (luminosité|intensité) (du|de) {entity}
-éclairci (le|l') {entity}
-rends (l'|le|la) {entity} plus (claire|lumineux|lumineuse)
+éclaircis (le|l') {entity}
+rends (l'|le|la) {entity} plus (clair|lumineux|lumineuse)

--- a/vocab/fr-fr/sensor.intent
+++ b/vocab/fr-fr/sensor.intent
@@ -1,1 +1,1 @@
-(quelle est|indique-moi|dit moi|donne-moi) (le|la|l') (valeure|état|status) (de|du) {Entity} (s'il te plaît|).
+(quelle est|quel est|indique-moi|dis-moi|donne-moi) (le|la|l') (valeur|état|statut) (de|du) {Entity} (s'il te plaît|).

--- a/vocab/fr-fr/set.climate.intent
+++ b/vocab/fr-fr/set.climate.intent
@@ -1,3 +1,3 @@
 règle {entity} à {temp} degrés
-défini la température (de|du) {entity} à {temp} degrés
+définis la température (de|du) {entity} à {temp} degrés
 modifie la température (de|du) {entity} à {temp} degrés

--- a/vocab/fr-fr/set.light.brightness.intent
+++ b/vocab/fr-fr/set.light.brightness.intent
@@ -1,1 +1,1 @@
-met la luminosité de {entity} à {brightnessvalue}%
+mets la luminosité de {entity} à {brightnessvalue}%

--- a/vocab/fr-fr/turn.off.intent
+++ b/vocab/fr-fr/turn.off.intent
@@ -1,4 +1,4 @@
-éteint {Entity}
+éteins {Entity}
 peux-tu éteindre {Entity} s'il te plait?
 j'aimerais éteindre {Entity}
 je souhaiterais éteindre {Entity}


### PR DESCRIPTION
#### Description
fixes #98
STT from Google understands imperative verbs when language is set to French language. However, some verbs are not in the correct French imperative form. These verbs are located in the files stored in `vocab/fr-fr` directory.

#### Type of PR

- [x] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Speak in French to Mycroft.
