### PR TITLE
replace "|" in home assistant entity attributes with ":" in the output dialog

### DIFF
--- a/ha_client.py
+++ b/ha_client.py
@@ -212,9 +212,9 @@ class HomeAssistantClient:
                     sensor_name = entity_attrs['friendly_name']
                     sensor_state = attr['state']
                     entity_attr = {
-                        "unit_measure": unit_measur,
-                        "name": sensor_name,
-                        "state": sensor_state
+                        "unit_measure": unit_measur.replace("|", ":"),
+                        "name": sensor_name.replace("|", ":"),
+                        "state": sensor_state.replace("|", ":")
                     }
                     return entity_attr
         return None

--- a/ha_client.py
+++ b/ha_client.py
@@ -180,6 +180,8 @@ class HomeAssistantClient:
                                 "attributes": state['attributes']}
                 except KeyError:
                     pass
+        if best_entity is not None:
+            best_entity["dev_name"] = best_entity["dev_name"].replace("|", ":")
         return best_entity
 
     def find_entity_attr(self, entity: str) -> dict:


### PR DESCRIPTION
#### Description
If e.g. the friendly name in home assistant contains a "|", this would cause mycroft to randomly speak the text either before or after this character.


#### Type of PR
- [x] Bugfix

#### Testing
_Note: I tested this with mycroft configured in german._

Rename the friendly name of an entity in home assistant to contain a "|" (for example "Battery | State of charge").
Then ask "Hey Mycroft, what is the state of battery state of charge"

Before, Mycroft would say something like:
"State of Charge is ..." or just "Battery"

Now, it should say:
"Battery : State of charge is ..."