### PR TITLE
Fix issue #121

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -152,7 +152,7 @@ class HomeAssistantSkill(FallbackSkill):
         """
         self._setup()
         if self.ha_client is None:
-            self.speak_dialog('homeassistant.error.setup')
+            self.speak_dialog('homeassistant.error.offline')
             return False
         # TODO if entity is 'all', 'any' or 'every' turn on
         # every single entity not the whole group
@@ -822,7 +822,7 @@ class HomeAssistantSkill(FallbackSkill):
             return False
         self._setup()
         if self.ha_client is None:
-            self.speak_dialog('homeassistant.error.setup')
+            self.speak_dialog('homeassistant.error.offline')
             return False
         # pass message to HA-server
         response = self._handle_client_exception(


### PR DESCRIPTION
#### Description
This PR fixes crash reported by @ramblurr  #121 occuring while informing user, that skill do not have connection to HA instance after running `_setup()`. Speaking dialog from `error.setup` cause error as it mean to inform about errors in setup stage and need aditional content `field`. Dialog from `error.offline` should be used in this option as we are pass setup stage and checking connection to HA instance.

#### Type of PR
- [x] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements
