### PR TITLE
Fix uncompleted dialogs when `|` is present in text.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -23,7 +23,7 @@ TIMEOUT = 10
 
 
 def _get_nice_number(number: str) -> str:
-    """Convert number to nice formated number"""
+    """Convert number to nice formatted number"""
     try:
         return nice_number(float(number))
     except TypeError:
@@ -91,7 +91,7 @@ class HomeAssistantSkill(FallbackSkill):
             if self.ha_client.connected():
                 # Check if conversation component is loaded at HA-server
                 # and activate fallback accordingly (ha-server/api/components)
-                # TODO: enable other tools like dialogflow
+                # TODO: enable other tools like dialog flow
                 conversation_activated = self.ha_client.find_component(
                     'conversation'
                 )
@@ -143,7 +143,7 @@ class HomeAssistantSkill(FallbackSkill):
 
     def on_websettings_changed(self) -> None:
         """
-        Force a setting refresh after the websettings changed
+        Force a setting refresh after the web settings changed
         otherwise new settings will not be regarded.
         """
         self._force_setup()
@@ -330,7 +330,7 @@ class HomeAssistantSkill(FallbackSkill):
     @intent_handler('add.item.shopping.list.intent')
     def handle_shopping_list_intent(self, message: Message) -> None:
         """Handle add item to shopping list intent."""
-        self.log.debug("Add %s to the shoping list", message.data.get("entity"))
+        self.log.debug("Add %s to the shopping list", message.data.get("entity"))
         message.data["Entity"] = message.data.get("entity")
         self._handle_shopping_list(message)
 
@@ -400,7 +400,7 @@ class HomeAssistantSkill(FallbackSkill):
             ]
         )
 
-        # Exit if entity not found or is unavailabe
+        # Exit if entity not found or is unavailable
         if not ha_entity or not self._check_availability(ha_entity):
             return
 
@@ -448,7 +448,7 @@ class HomeAssistantSkill(FallbackSkill):
         self.log.debug("Brightness Percent: %s", brightness_percentage)
 
         ha_entity = self._find_entity(entity, ['group', 'light'])
-        # Exit if entity not found or is unavailabe
+        # Exit if entity not found or is unavailable
         if not ha_entity or not self._check_availability(ha_entity):
             return
 
@@ -524,7 +524,7 @@ class HomeAssistantSkill(FallbackSkill):
         entity = message.data["Entity"]
 
         ha_entity = self._find_entity(entity, ['cover'])
-        # Exit if entity not found or is unavailabe
+        # Exit if entity not found or is unavailable
         if not ha_entity or not self._check_availability(ha_entity):
             return
 
@@ -616,7 +616,7 @@ class HomeAssistantSkill(FallbackSkill):
             return
 
     def _handle_automation(self, message: Message) -> None:
-        """Handler for triggering automations."""
+        """Handler for triggering automation."""
         entity = message.data["Entity"]
         self.log.debug("Entity: %s", entity)
         ha_entity = self._find_entity(
@@ -624,7 +624,7 @@ class HomeAssistantSkill(FallbackSkill):
             ['automation', 'scene', 'script']
         )
 
-        # Exit if entity not found or is unavailabe
+        # Exit if entity not found or is unavailable
         if not ha_entity or not self._check_availability(ha_entity):
             return
 
@@ -682,7 +682,7 @@ class HomeAssistantSkill(FallbackSkill):
             ]
         )
 
-        # Exit if entity not found or is unavailabe
+        # Exit if entity not found or is unavailable
         if not ha_entity or not self._check_availability(ha_entity):
             return
 
@@ -764,7 +764,7 @@ class HomeAssistantSkill(FallbackSkill):
         self.log.debug("Entity: %s", entity)
 
         ha_entity = self._find_entity(entity, ['device_tracker'])
-        # Exit if entity not found or is unavailabe
+        # Exit if entity not found or is unavailable
         if not ha_entity or not self._check_availability(ha_entity):
             return
 
@@ -787,7 +787,7 @@ class HomeAssistantSkill(FallbackSkill):
         self.log.debug("Temperature: %s", temperature)
 
         ha_entity = self._find_entity(entity, ['climate'])
-        # Exit if entity not found or is unavailabe
+        # Exit if entity not found or is unavailable
         if not ha_entity or not self._check_availability(ha_entity):
             return
 

--- a/__init__.py
+++ b/__init__.py
@@ -14,7 +14,7 @@ from requests.exceptions import (HTTPError, InvalidURL, RequestException,
 # pylint: disable=E0401
 from requests.packages.urllib3.exceptions import MaxRetryError
 
-from .ha_client import HomeAssistantClient, check_url
+from .ha_client import HomeAssistantClient, check_url, normalize_dialog
 
 __author__ = 'robconnolly, btotharye, nielstron'
 
@@ -43,6 +43,14 @@ class HomeAssistantSkill(FallbackSkill):
         self.enable_fallback = False
         self.tracker_file = ""
 
+    @normalize_dialog
+    def _speak_dialog(self, *arg, **kwarg) -> None:
+        """Speak dialog after a text normalization"""
+
+        self.log.info("Dialog")
+
+        self.speak_dialog(*arg, **kwarg)
+
     def _setup(self, force: bool = False) -> None:
         if self.settings is not None and (force or self.ha_client is None):
             # Check if user filled IP, port and Token in configuration
@@ -52,12 +60,12 @@ class HomeAssistantSkill(FallbackSkill):
             """Inform user if ip/url or token not or incorrectly filed"""
             if not ip_address:
 
-                self.speak_dialog('homeassistant.error.setup', data={
+                self._speak_dialog('homeassistant.error.setup', data={
                               "field": "I.P."})
                 return
 
             if not token:
-                self.speak_dialog('homeassistant.error.setup', data={
+                self._speak_dialog('homeassistant.error.setup', data={
                               "field": "token"})
                 return
 
@@ -68,7 +76,7 @@ class HomeAssistantSkill(FallbackSkill):
                 port_number = 8123
             except ValueError:
                 # String might be some rubbish (like '')
-                self.speak_dialog('homeassistant.error.setup', data={
+                self._speak_dialog('homeassistant.error.setup', data={
                               "field": "port"})
                 return
 
@@ -152,14 +160,14 @@ class HomeAssistantSkill(FallbackSkill):
         """
         self._setup()
         if self.ha_client is None:
-            self.speak_dialog('homeassistant.error.setup')
+            self._speak_dialog('homeassistant.error.setup')
             return False
         # TODO if entity is 'all', 'any' or 'every' turn on
         # every single entity not the whole group
         ha_entity = self._handle_client_exception(self.ha_client.find_entity,
                                                   entity, domains)
         if ha_entity is None:
-            self.speak_dialog('homeassistant.error.device.unknown', data={
+            self._speak_dialog('homeassistant.error.device.unknown', data={
                               "dev_name": entity})
         return ha_entity
 
@@ -174,7 +182,7 @@ class HomeAssistantSkill(FallbackSkill):
         if ha_entity['state'] == 'unavailable':
             """Check if state is unavailable, if yes, inform user about it."""
 
-            self.speak_dialog('homeassistant.error.device.unavailable', data={
+            self._speak_dialog('homeassistant.error.device.unavailable', data={
                             "dev_name": ha_entity['dev_name']})
             """Return result to underlining function."""
             return False
@@ -188,27 +196,27 @@ class HomeAssistantSkill(FallbackSkill):
         try:
             return callback(*args, **kwargs)
         except Timeout:
-            self.speak_dialog('homeassistant.error.offline')
+            self._speak_dialog('homeassistant.error.offline')
         except (InvalidURL, URLRequired, MaxRetryError) as error:
             if error.request is None or error.request.url is None:
                 # There is no url configured
-                self.speak_dialog('homeassistant.error.needurl')
+                self._speak_dialog('homeassistant.error.needurl')
             else:
-                self.speak_dialog('homeassistant.error.invalidurl', data={
+                self._speak_dialog('homeassistant.error.invalidurl', data={
                                   'url': error.request.url})
         except SSLError:
-            self.speak_dialog('homeassistant.error.ssl')
+            self._speak_dialog('homeassistant.error.ssl')
         except HTTPError as error:
             # check if due to wrong password
             if error.response.status_code == 401:
-                self.speak_dialog('homeassistant.error.wrong_password')
+                self._speak_dialog('homeassistant.error.wrong_password')
             else:
-                self.speak_dialog('homeassistant.error.http', data={
+                self._speak_dialog('homeassistant.error.http', data={
                     'code': error.response.status_code,
                     'reason': error.response.reason})
         except (ConnectionError, RequestException) as exception:
             # TODO find a nice member of any exception to output
-            self.speak_dialog('homeassistant.error', data={
+            self._speak_dialog('homeassistant.error', data={
                     'url': exception.request.url})
 
         return False
@@ -331,7 +339,7 @@ class HomeAssistantSkill(FallbackSkill):
         entity = message.data["Entity"]
 
         if not self.gui.connected:
-            self.speak_dialog('homeassistant.error.no_gui')
+            self._speak_dialog('homeassistant.error.no_gui')
             return
 
         ha_entity = self._find_entity(entity, ['camera'])
@@ -369,7 +377,7 @@ class HomeAssistantSkill(FallbackSkill):
                 ha_data = {'entity_id': 'all'}
 
                 self.ha_client.execute_service(domain, "turn_{action}", ha_data)
-                self.speak_dialog(f'homeassistant.device.{action}', data=ha_entity)
+                self._speak_dialog(f'homeassistant.device.{action}', data=ha_entity)
                 return
         # TODO: need to figure out, if this indeed throws a KeyError
         except KeyError:
@@ -404,7 +412,7 @@ class HomeAssistantSkill(FallbackSkill):
         # self.set_context('Entity', ha_entity['dev_name'])
         if ha_entity['state'] == action:
             self.log.debug("Entity in requested state")
-            self.speak_dialog('homeassistant.device.already', data={
+            self._speak_dialog('homeassistant.device.already', data={
                 "dev_name": ha_entity['dev_name'], 'action': action})
         elif action == "toggle":
             self.ha_client.execute_service("homeassistant", "toggle",
@@ -413,15 +421,15 @@ class HomeAssistantSkill(FallbackSkill):
                 action = 'on'
             else:
                 action = 'off'
-            self.speak_dialog(f'homeassistant.device.{action}',
-                              data=ha_entity)
+            self._speak_dialog(f'homeassistant.device.{action}',
+                               data=ha_entity)
         elif action in ["on", "off"]:
-            self.speak_dialog(f'homeassistant.device.{action}',
-                              data=ha_entity)
+            self._speak_dialog(f'homeassistant.device.{action}',
+                               data=ha_entity)
             self.ha_client.execute_service("homeassistant", f"turn_{action}",
                                            ha_data)
         else:
-            self.speak_dialog('homeassistant.error.sorry')
+            self._speak_dialog('homeassistant.error.sorry')
             return
 
     def _handle_light_set(self, message: Message) -> None:
@@ -430,7 +438,7 @@ class HomeAssistantSkill(FallbackSkill):
         try:
             brightness_req = float(message.data["Brightnessvalue"])
             if brightness_req > 100 or brightness_req < 0:
-                self.speak_dialog('homeassistant.brightness.badreq')
+                self._speak_dialog('homeassistant.brightness.badreq')
         except KeyError:
             brightness_req = 10.0
         brightness_value = int(brightness_req / 100 * 255)
@@ -454,8 +462,8 @@ class HomeAssistantSkill(FallbackSkill):
         # Set values for Mycroft reply
         ha_data['dev_name'] = ha_entity['dev_name']
         ha_data['brightness'] = brightness_req
-        self.speak_dialog('homeassistant.brightness.dimmed',
-                          data=ha_data)
+        self._speak_dialog('homeassistant.brightness.dimmed',
+                           data=ha_data)
 
         return
 
@@ -464,7 +472,7 @@ class HomeAssistantSkill(FallbackSkill):
         entity = message.data["Entity"]
         ha_data = {'name': entity}
         self.ha_client.execute_service("shopping_list", "add_item", ha_data)
-        self.speak_dialog("homeassistant.shopping.list")
+        self._speak_dialog("homeassistant.shopping.list")
 
     def _handle_open_close_actions(self, message: Message) -> None:
         """Handler for open and close actions."""
@@ -473,7 +481,7 @@ class HomeAssistantSkill(FallbackSkill):
 
         if self.voc_match(entity, "HomeAssistant"):
             if not self.gui.connected:
-                self.speak_dialog('homeassistant.error.no_gui')
+                self._speak_dialog('homeassistant.error.no_gui')
                 return
 
             if action == "open":
@@ -502,11 +510,11 @@ class HomeAssistantSkill(FallbackSkill):
                 return
 
             if action == "open":
-                self.speak_dialog("homeassistant.device.opening",
-                                  data=ha_entity)
+                self._speak_dialog("homeassistant.device.opening",
+                                   data=ha_entity)
             elif action == "close":
-                self.speak_dialog("homeassistant.device.closing",
-                                  data=ha_entity)
+                self._speak_dialog("homeassistant.device.closing",
+                                   data=ha_entity)
             return
 
         return
@@ -531,8 +539,8 @@ class HomeAssistantSkill(FallbackSkill):
             if response.status_code != 200:
                 return
 
-            self.speak_dialog("homeassistant.device.stopped",
-                              data=ha_entity)
+            self._speak_dialog("homeassistant.device.stopped",
+                               data=ha_entity)
             return
         return
 
@@ -562,12 +570,12 @@ class HomeAssistantSkill(FallbackSkill):
 
         if action == "down":
             if ha_entity['state'] == "off":
-                self.speak_dialog('homeassistant.brightness.cantdim.off',
-                                  data=ha_entity)
+                self._speak_dialog('homeassistant.brightness.cantdim.off',
+                                   data=ha_entity)
             else:
                 light_attrs = self.ha_client.find_entity_attr(ha_entity['id'])
                 if light_attrs['unit_measure'] == "":
-                    self.speak_dialog(
+                    self._speak_dialog(
                         'homeassistant.brightness.cantdim.dimmable',
                         data=ha_entity)
                 else:
@@ -579,17 +587,17 @@ class HomeAssistantSkill(FallbackSkill):
                                                    ha_data)
                     ha_data['dev_name'] = ha_entity['dev_name']
                     ha_data['brightness'] = round(100 / max_brightness * ha_data['brightness'])
-                    self.speak_dialog('homeassistant.brightness.decreased',
-                                      data=ha_data)
+                    self._speak_dialog('homeassistant.brightness.decreased',
+                                       data=ha_data)
         elif action == "up":
             if ha_entity['state'] == "off":
-                self.speak_dialog(
+                self._speak_dialog(
                     'homeassistant.brightness.cantdim.off',
                     data=ha_entity)
             else:
                 light_attrs = self.ha_client.find_entity_attr(ha_entity['id'])
                 if light_attrs['unit_measure'] == "":
-                    self.speak_dialog(
+                    self._speak_dialog(
                         'homeassistant.brightness.cantdim.dimmable',
                         data=ha_entity)
                 else:
@@ -601,10 +609,10 @@ class HomeAssistantSkill(FallbackSkill):
                                                    ha_data)
                     ha_data['dev_name'] = ha_entity['dev_name']
                     ha_data['brightness'] = round(100 / max_brightness * ha_data['brightness'])
-                    self.speak_dialog('homeassistant.brightness.increased',
-                                      data=ha_data)
+                    self._speak_dialog('homeassistant.brightness.increased',
+                                       data=ha_data)
         else:
-            self.speak_dialog('homeassistant.error.sorry')
+            self._speak_dialog('homeassistant.error.sorry')
             return
 
     def _handle_automation(self, message: Message) -> None:
@@ -628,16 +636,16 @@ class HomeAssistantSkill(FallbackSkill):
         self.log.debug("Triggered automation/scene/script: %s", ha_entity['id'])
         if "automation" in ha_entity['id']:
             self.ha_client.execute_service('automation', 'trigger', ha_data)
-            self.speak_dialog('homeassistant.automation.trigger',
-                              data={"dev_name": ha_entity['dev_name']})
+            self._speak_dialog('homeassistant.automation.trigger',
+                               data={"dev_name": ha_entity['dev_name']})
         elif "script" in ha_entity['id']:
-            self.speak_dialog('homeassistant.automation.trigger',
-                              data={"dev_name": ha_entity['dev_name']})
+            self._speak_dialog('homeassistant.automation.trigger',
+                               data={"dev_name": ha_entity['dev_name']})
             self.ha_client.execute_service("script", "turn_on",
                                            data=ha_data)
         elif "scene" in ha_entity['id']:
-            self.speak_dialog('homeassistant.scene.on',
-                              data=ha_entity)
+            self._speak_dialog('homeassistant.scene.on',
+                               data=ha_entity)
             self.ha_client.execute_service("scene", "turn_on",
                                            data=ha_data)
 
@@ -646,13 +654,13 @@ class HomeAssistantSkill(FallbackSkill):
         current_temp = _get_nice_number(attr['current_temperature'])
         target_temp = _get_nice_number(attr['temperature'])
         if current_temp:
-            self.speak_dialog('homeassistant.sensor.thermostat.current', data={
+            self._speak_dialog('homeassistant.sensor.thermostat.current', data={
                 "dev_name": name,
                 "value": state,
                 "current_temp": current_temp,
                 "targeted_temp": target_temp})
         else:
-            self.speak_dialog('homeassistant.sensor.thermostat', data={
+            self._speak_dialog('homeassistant.sensor.thermostat', data={
                 "dev_name": name,
                 "value": state,
                 "targeted_temp": target_temp})
@@ -712,8 +720,8 @@ class HomeAssistantSkill(FallbackSkill):
                 sensor_state
             )
         elif domain == "cover":
-            self.speak_dialog(f'homeassistant.device.{sensor_state}', data={
-                "dev_name": sensor_name})
+            self._speak_dialog(f'homeassistant.device.{sensor_state}', data={
+                 "dev_name": sensor_name})
 
             sensor_states = self.translate_namedvalues(
                 'homeassistant.sensor.cover.state')
@@ -728,13 +736,13 @@ class HomeAssistantSkill(FallbackSkill):
             if attributes.get('device_class') in sensor_states:
                 sensor_state = sensor_states[attributes['device_class']]
 
-            self.speak_dialog('homeassistant.sensor.binary_sensor', data={
+            self._speak_dialog('homeassistant.sensor.binary_sensor', data={
                 "dev_name": sensor_name,
                 "value": sensor_state})
 
             self._display_sensor_dialog(sensor_name, sensor_state)
         else:
-            self.speak_dialog('homeassistant.sensor', data={
+            self._speak_dialog('homeassistant.sensor', data={
                 "dev_name": sensor_name,
                 "value": sensor_state,
                 "unit": sensor_unit})
@@ -766,9 +774,9 @@ class HomeAssistantSkill(FallbackSkill):
         entity = ha_entity['id']
         dev_name = ha_entity['dev_name']
         dev_location = ha_entity['state']
-        self.speak_dialog('homeassistant.tracker.found',
-                          data={'dev_name': dev_name,
-                                'location': dev_location})
+        self._speak_dialog('homeassistant.tracker.found',
+                           data={'dev_name': dev_name,
+                                 'location': dev_location})
 
     def _handle_set_thermostat(self, message: Message) -> None:
         """Handler for setting thermostats."""
@@ -794,7 +802,7 @@ class HomeAssistantSkill(FallbackSkill):
             data=climate_data
         )
 
-        self.speak_dialog(
+        self._speak_dialog(
             'homeassistant.set.thermostat',
             data={
                 "dev_name": climate_attr['name'],
@@ -822,7 +830,7 @@ class HomeAssistantSkill(FallbackSkill):
             return False
         self._setup()
         if self.ha_client is None:
-            self.speak_dialog('homeassistant.error.setup')
+            self._speak_dialog('homeassistant.error.setup')
             return False
         # pass message to HA-server
         response = self._handle_client_exception(

--- a/ha_client.py
+++ b/ha_client.py
@@ -81,6 +81,33 @@ def check_url(ip_address: str) -> str:
     return None
 
 
+def _normalize_string(string: str) -> str:
+    """Normalize string for speak"""
+
+    if not isinstance(string, str):
+        # String is not string, skip normalization
+        return string
+
+    string = string.replace("|", ",")
+    return string
+
+
+def normalize_dialog(func) -> None:
+    """Decorator for dialog speak normalization"""
+
+    def norm(*args, **kwargs):
+        """Run normalization on all data"""
+
+        for kwargKey in kwargs.keys():
+            if kwargKey == 'data':
+                for key in kwargs[kwargKey]:
+                    kwargs[kwargKey][key] = _normalize_string(kwargs[kwargKey][key])
+
+        func(*args, **kwargs)
+
+    return norm
+
+
 # pylint: disable=R0912, W0105, W0511
 class HomeAssistantClient:
     """Home Assistant client class"""

--- a/unittests/__init__.py
+++ b/unittests/__init__.py
@@ -1,4 +1,4 @@
-"""Add parrent directory to python path - fix pylint error"""
+"""Add parent directory to python path - fix pylint error"""
 import os
 import sys
 

--- a/unittests/test_haclient.py
+++ b/unittests/test_haclient.py
@@ -39,7 +39,7 @@ config = {'ip_address': '127.0.0.1',
 class TestHaClient(TestCase):
     """Base set of tests
 
-    These tests are from old days and originally runned on public
+    These tests are from old days and originally run on public
     instance of HA that no longer runs so mocking was added.
     """
 

--- a/unittests/test_haclient.py
+++ b/unittests/test_haclient.py
@@ -3,7 +3,8 @@ import os
 import unittest
 from unittest import TestCase, mock
 
-from ha_client import HomeAssistantClient, check_url
+from ha_client import (HomeAssistantClient, _normalize_string, check_url,
+                       normalize_dialog)
 
 kitchen_light = {'state': 'off', 'id': '1', 'dev_name': 'kitchen'}
 
@@ -295,6 +296,53 @@ class TestUrlChecker(TestCase):
             matches = check_url(address)
 
         self.assertEqual(matches, None)
+
+
+class TestAdditionalFunctions(TestCase):
+    """Base set of additional functions"""
+
+    def test_normalize_string(self):
+        """Test string normalizing function
+        Test cases contain in/out duos which should be equal"""
+        test_case = [
+            ['Battery | State of charge', 'Battery , State of charge'],
+            ['Bathroom light', 'Bathroom light'],
+        ]
+
+        # Run all test cases
+        for duo in test_case:
+            normalized = _normalize_string(duo[0])
+            self.assertEqual(normalized, duo[1])
+
+    def test_normalize_dialog(self) -> None:
+        """Test dialog normalizing function used as decorator.
+        Test cases contain in/out duos which should be equal"""
+        test_dialog = "sensor.state"
+        test_case = [
+            # test replace | to ,
+            [{"entity": 'Battery | State of charge'}, {"entity": 'Battery , State of charge'}],
+            # test int in value
+            [{"entity": 'Bathroom light', "val": 124}, {"entity": 'Bathroom light', "val": 124}],
+            # test empty dict
+            [{}, {}],
+            # test multiple keys
+            [{"entity": "Batt | Charge", "state": "3.7V , 2A"}, {"entity": "Batt , Charge", "state": "3.7V , 2A"}]
+
+        ]
+
+        @normalize_dialog
+        def _speak_dialog(dialog, data=None):
+            """Mock speak_dialog function"""
+
+            # Check dialog did not change
+            self.assertEqual(dialog, test_dialog)
+            # Check if first dialog in list was changed into second one
+            self.assertEqual(data, duo[1])
+
+        # Run all test cases
+        for duo in test_case:
+            # run mocked speak dialog with decorator
+            _speak_dialog(test_dialog, data=duo[0])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#### Description
Hi, this PR is successor of PR #107 made by [PocketMiner82](https://github.com/PocketMiner82) (With his approve)

Main goal of PR is to change entitiy name if it contain symbol `|` as it cause problems when speaking dialogs. Text after `|` is not read.

To preserve enitity name in original, text normalization is done only to dialogs.

New internal function `_speak_dialog` is presented and used with a new decorator function `normalize_dialog` to handle text normalization a hand it then to standard `speak_dialog`. Not only entity name is normalized.

#### Type of PR
- [x] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
New unittests are present for a new functions.

#### Documentation
All new functions have a basic informaition in docstrings.